### PR TITLE
Add crawler-visible SEO fallback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,37 @@
     <link rel="stylesheet" href='https://fonts.googleapis.com/css2?family=Roboto:wght@300;500;700&display=swap' />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap">
+    <style>
+      .azu-seo-fallback {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 2rem 1.25rem;
+        color: #1f1f1f;
+        font-family: Roboto, Arial, sans-serif;
+        line-height: 1.55;
+      }
+
+      .azu-seo-fallback h1,
+      .azu-seo-fallback h2 {
+        font-family: Montserrat, Roboto, Arial, sans-serif;
+        line-height: 1.2;
+      }
+
+      .azu-seo-fallback__nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin: 1rem 0 1.5rem;
+      }
+
+      .azu-seo-fallback a {
+        color: #8a1538;
+      }
+
+      #root:not(:empty) + .azu-seo-fallback {
+        display: none;
+      }
+    </style>
     <title>Arreplegats de la Zona Universitària</title>
 
     <!--
@@ -66,6 +97,60 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <section class="azu-seo-fallback" aria-label="Contingut principal dels Arreplegats">
+      <h1>Arreplegats de la Zona Universitària</h1>
+      <p>
+        Web oficial dels Arreplegats de la Zona Universitària, colla castellera universitària de Barcelona amb més de 25 anys d'història.
+        Fem castells amb persones matriculades a la universitat i som coneguts per haver dut el món casteller universitari fins als castells de vuit.
+      </p>
+
+      <nav class="azu-seo-fallback__nav" aria-label="Pàgines principals">
+        <a href="/">Inici</a>
+        <a href="/qui-som">Qui som</a>
+        <a href="/assajos">Assajos</a>
+        <a href="/historia-de-la-colla">Història de la colla</a>
+        <a href="/millors-castells">Millors castells</a>
+        <a href="/contactar">Contactar</a>
+      </nav>
+
+      <article>
+        <h2><a href="/qui-som">Qui som?</a></h2>
+        <p>
+          Som una colla castellera universitària que alça castells, torres i pilars amb castellers adults.
+          Hem fet construccions com el 4 de 8, el 3 de 8 amb folre i la torre de 8 amb folre i manilles.
+        </p>
+      </article>
+
+      <article>
+        <h2><a href="/assajos">Assajos</a></h2>
+        <p>
+          Assagem dimarts i dijous al migdia, de 14:00 a 16:00, al pati d'Industrials (ETSEIB), i dijous al vespre, de 20:00 a 22:00, al gimnàs d'assaig dels Castellers de Sants.
+          No cal experiència prèvia: l'equip d'acollida rep les persones noves i les ajuda a trobar el seu lloc a la colla.
+        </p>
+      </article>
+
+      <article>
+        <h2><a href="/historia-de-la-colla">Història de la colla</a></h2>
+        <p>
+          Fundats la primavera de 1995, vam ser la segona colla castellera universitària.
+          El 2009 vam descarregar el primer 4 de 8 universitari, el 2013 el pilar de 7 amb folre i manilles, i el 2014 el primer 3 de 8 amb folre del món universitari.
+        </p>
+      </article>
+
+      <article>
+        <h2><a href="/millors-castells">Millors castells</a></h2>
+        <p>
+          Entre els nostres millors castells hi ha la torre de 8 amb folre i manilles, el pilar de 7 amb folre i manilles, el 4 de 8, el 3 de 8 amb folre, el 9 de 7 i el 5 de 7.
+        </p>
+      </article>
+
+      <article>
+        <h2><a href="/contactar">Contacta'ns</a></h2>
+        <p>
+          Pots escriure'ns a <a href="mailto:junta.arreplegats@gmail.com">junta.arreplegats@gmail.com</a> o seguir-nos a les xarxes socials com @arreplegats per estar al dia dels assajos, actuacions i activitats.
+        </p>
+      </article>
+    </section>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION
## Summary
- Adds a compact crawler-visible SEO fallback section to the static HTML shell.
- Includes core copy and internal links for the homepage, `qui-som`, `assajos`, `historia-de-la-colla`, `millors-castells`, and `contactar`.
- Hides the fallback once React renders so hydration and the normal app UI remain unchanged.

## Test plan
- `npm run build`

Note: build still reports pre-existing `CastellsGame.js` unreachable-code warnings and an outdated Browserslist notice.

Made with [Cursor](https://cursor.com)