### PR TITLE
Optimize homepage hero LCP

### DIFF
--- a/src/components/HomeHero.js
+++ b/src/components/HomeHero.js
@@ -1,0 +1,50 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { buildHeroSrcSet, getHeroFallbackImage, HOME_HERO_IMAGES } from "../data/homeHeroImages";
+
+const HERO_LINKS = [
+	{ to: "/assajos", label: "UNEIX-T'HI" },
+	{ to: "/agenda", label: "AGENDA" },
+	{ to: "/contactar", label: "CONTACTA'NS!" },
+];
+
+function HomeHero({ images = HOME_HERO_IMAGES }) {
+	const fallbackImage = getHeroFallbackImage(images);
+	const srcSet = buildHeroSrcSet(images);
+
+	return (
+		<section className="home-hero" aria-labelledby="home-hero-title">
+			<picture className="home-hero__picture">
+				<source srcSet={srcSet} sizes="100vw" />
+				<img
+					className="home-hero__image"
+					src={fallbackImage.url}
+					srcSet={srcSet}
+					sizes="100vw"
+					width={fallbackImage.width}
+					height={fallbackImage.height}
+					alt="Arreplegats aixecant un castell"
+					fetchpriority="high"
+					loading="eager"
+					decoding="async"
+				/>
+			</picture>
+			<div className="home-hero__overlay"></div>
+			<div className="home-hero__content">
+				<h1 id="home-hero-title" className="home-hero__title">
+					ARREPLEGATS
+				</h1>
+				<h3 className="home-hero__tagline">ELS ÚNICS QUE HO PODEN FER</h3>
+				<div className="home-hero__buttons">
+					{HERO_LINKS.map((link) => (
+						<NavLink key={link.to} to={link.to} className="home-hero__button">
+							{link.label}
+						</NavLink>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}
+
+export default HomeHero;

--- a/src/components/HomeHero.test.js
+++ b/src/components/HomeHero.test.js
@@ -1,0 +1,30 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import HomeHero from "./HomeHero";
+import { buildHeroSrcSet, getHeroFallbackImage, HOME_HERO_IMAGES } from "../data/homeHeroImages";
+
+describe("HomeHero", () => {
+	it("renders the responsive homepage hero with primary calls to action", () => {
+		render(
+			<MemoryRouter>
+				<HomeHero />
+			</MemoryRouter>
+		);
+
+		const fallbackImage = getHeroFallbackImage(HOME_HERO_IMAGES);
+		const heroImage = screen.getByRole("img", { name: "Arreplegats aixecant un castell" });
+
+		expect(screen.getByRole("heading", { level: 1, name: "ARREPLEGATS" })).toBeInTheDocument();
+		expect(screen.getByRole("heading", { level: 3, name: "ELS ÚNICS QUE HO PODEN FER" })).toBeInTheDocument();
+		expect(heroImage).toHaveAttribute("src", fallbackImage.url);
+		expect(heroImage).toHaveAttribute("srcset", buildHeroSrcSet(HOME_HERO_IMAGES));
+		expect(heroImage).toHaveAttribute("sizes", "100vw");
+		expect(heroImage).toHaveAttribute("width", String(fallbackImage.width));
+		expect(heroImage).toHaveAttribute("height", String(fallbackImage.height));
+		expect(heroImage).toHaveAttribute("fetchpriority", "high");
+		expect(screen.getByRole("link", { name: "UNEIX-T'HI" })).toHaveAttribute("href", "/assajos");
+		expect(screen.getByRole("link", { name: "AGENDA" })).toHaveAttribute("href", "/agenda");
+		expect(screen.getByRole("link", { name: "CONTACTA'NS!" })).toHaveAttribute("href", "/contactar");
+	});
+});

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -822,22 +822,28 @@ Home
 ===============
 */
 
-.home-buttons {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 10px;
-}
-
-.welcome-image {
+.home-hero {
 	height: calc(100vh - 5rem);
-	background-position: center 15%;
-	background-size: cover;
-	background-repeat: no-repeat;
 	width: 100vw;
+	margin: 0;
+	padding: 0;
 	position: relative;
+	overflow: hidden;
 }
 
-.overlay {
+.home-hero__picture,
+.home-hero__image {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+.home-hero__image {
+	object-fit: cover;
+	object-position: center 15%;
+}
+
+.home-hero__overlay {
 	background-color: rgba(21, 168, 132, 0.5);
 	position: absolute;
 	top: 0;
@@ -845,9 +851,10 @@ Home
 	bottom: 0;
 	left: 0;
 	z-index: 2;
+	pointer-events: none;
 }
 
-.content {
+.home-hero__content {
 	position: absolute;
 	top: 25%;
 	left: calc((100vw - var(--page-width)) / 2);
@@ -855,38 +862,47 @@ Home
 	user-select: none;
 	z-index: 3;
 }
-.content * {
+
+.home-hero__content * {
 	margin: 0;
 	font-family: 'Montserrat';
 }
 
 @media screen and (max-width: 1250px) {
-	.content {
+	.home-hero__content {
 		left: calc((100vw - var(--mobile-width)) / 2);
 	}
 }
 
-.content h1 {
+.home-hero__title {
 	font-size: 10vw;
 	font-weight: 700;
 	line-height: 0.8;
 }
 
-.content h3 {
+.home-hero__tagline {
 	font-size: max(1rem, 3.5vw);
 	font-weight: 700;
 	margin-top: 10px;
 	margin-bottom: 3rem;
 }
 
-.hero-btn {
+.home-hero__buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.home-hero__button {
 	border: 1px solid var(--white);
 	color: var(--white);
+	display: inline-flex;
 	padding: 15px 20px;
 	font-weight: 500;
 	transition: var(--transition);
 }
-.hero-btn:hover {
+
+.home-hero__button:hover {
 	color: var(--primary-600);
 	background-color: rgba(255, 255, 255, 0.6);
 }

--- a/src/data/homeHeroImages.js
+++ b/src/data/homeHeroImages.js
@@ -1,0 +1,15 @@
+export const HOME_HERO_IMAGES = [
+	{ width: 576, height: 384, url: "images/resized/2d8fm-arreplegats-2016-576_x_384.jpeg" },
+	{ width: 768, height: 512, url: "images/resized/2d8fm-arreplegats-2016-768_x_512.jpeg" },
+	{ width: 992, height: 661, url: "images/resized/2d8fm-arreplegats-2016-992_x_661.jpeg" },
+	{ width: 1200, height: 800, url: "images/resized/2d8fm-arreplegats-2016-1200_x_800.jpeg" },
+	{ width: 1920, height: 1280, url: "images/resized/2d8fm-arreplegats-2016-1920_x_1280.jpeg" },
+];
+
+export function buildHeroSrcSet(images) {
+	return images.map((img) => `${img.url} ${img.width}w`).join(", ");
+}
+
+export function getHeroFallbackImage(images = HOME_HERO_IMAGES) {
+	return images.find((img) => img.width === 1200) || images[0];
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,40 +1,17 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
 import CastellCard from "../components/CastellCard";
+import HomeHero from "../components/HomeHero";
 import Quote from "../components/Quote";
 import castells_map from "../data/castells-top.json";
 import quotes from "../data/quotes.json";
 
 class Home extends Component {
 	render() {
-		const random_quotes = quotes.sort(() => 0.5 - Math.random()).slice(0, 3);
-
-		const imageSizes = [
-			{ size: '576', url: 'images/resized/2d8fm-arreplegats-2016-576_x_384.jpeg' },
-			{ size: '768', url: 'images/resized/2d8fm-arreplegats-2016-768_x_512.jpeg' },
-			{ size: '992', url: 'images/resized/2d8fm-arreplegats-2016-992_x_661.jpeg' },
-			{ size: '1200', url: 'images/resized/2d8fm-arreplegats-2016-1200_x_800.jpeg' },
-			{ size: '1920', url: 'images/resized/2d8fm-arreplegats-2016-1920_x_1280.jpeg' },
-			{ size: 'max', url: 'images/2d8fm-arreplegats-2016.png' },
-		];
+		const randomQuotes = [...quotes].sort(() => 0.5 - Math.random()).slice(0, 3);
 
 		return (<>
-			{
-				imageSizes.map((img, i) => (
-					<section key={`resized-section-${i}`} className={`welcome-image resized-img img-${img.size}`} style={{backgroundImage: `url('${img.url}')`}}>
-						<div className="overlay"></div>
-						<div className="content">
-							<h1>ARREPLEGATS</h1>
-							<h3>ELS ÚNICS QUE HO PODEN FER</h3>
-							<div className="home-buttons">
-								<NavLink to="/assajos" className="hero-btn">UNEIX-T'HI</NavLink>
-								<NavLink to="/agenda" className="hero-btn">AGENDA</NavLink>
-								<NavLink to="/contactar" className="hero-btn">CONTACTA'NS!</NavLink>
-							</div>
-						</div>
-					</section>
-				))
-			}
+			<HomeHero />
 			<section style={{paddingTop: `2rem`}}>
 				<div className="floating-titles">
 					<h4>Els millors castells</h4>
@@ -57,7 +34,7 @@ class Home extends Component {
 				<h4>Què diu la gent?</h4>
 				<div className="quotes">
 					{
-						random_quotes.map((e, i) => {
+						randomQuotes.map((e, i) => {
 							return <Quote
 								quote={e.quote}
 								author={e.author}


### PR DESCRIPTION
## Summary
- Replaces the repeated hidden hero background sections with one semantic responsive `picture`/`img`.
- Adds `srcSet`, `sizes`, explicit dimensions, eager loading, and high fetch priority for the LCP image.
- Scopes the new styling to unique `home-hero__*` classes and avoids the original oversized max image candidate.

## Test plan
- `npm run build`

Note: build still reports pre-existing `CastellsGame.js` unreachable-code warnings and an outdated Browserslist notice.

Made with [Cursor](https://cursor.com)