### PR TITLE
Strengthen core page intro copy

### DIFF
--- a/src/pages/Assajos.js
+++ b/src/pages/Assajos.js
@@ -7,11 +7,11 @@ class Assajos extends Component {
 				<h2>Assajos</h2>
 
 				<p>
-					Els bons castells no surten del no-res: s'han d'assajar. Ens reunim dos dies a la setmana per fer història assaig a assaig.
+					Els assajos són el punt de trobada de la colla a Barcelona: el lloc on aprenem, fem pinya i preparem cada castell amb seguretat.
 				</p>
 
 				<p>
-					Vine-hi! El nostre equip d'acollida et rebrà amb els braços oberts. No cal saber-ne gens, només et cal una camisa antiga.
+					Vine-hi! Ens reunim dos dies a la setmana i el nostre equip d'acollida et rebrà amb els braços oberts. No cal saber-ne gens, només et cal una camisa antiga.
 				</p>
 			</section>
 			<section>

--- a/src/pages/Contactar.js
+++ b/src/pages/Contactar.js
@@ -6,6 +6,10 @@ class Contactar extends Component {
 			<section>
 				<h2>Contacta'ns</h2>
 
+				<p>
+					Vols venir a assaig, proposar una actuació o parlar amb la colla? Escriu-nos i t'ajudarem a trobar la millor manera de sumar-te als Arreplegats.
+				</p>
+
 				<ul className="contact-info">
 					<li><img src="/font-awesome/mail.svg" alt="Email" style={{ width: '14px', height: '14px' }} /> Correu electrònic: <a href="mailto:junta.arreplegats@gmail.com">junta.arreplegats@gmail.com</a></li>
 					<br />

--- a/src/pages/HistoriaDeLaColla.js
+++ b/src/pages/HistoriaDeLaColla.js
@@ -34,6 +34,10 @@ class HistoriaDeLaColla extends Component {
 			<section className="historia">
 				<h2>Història de la colla</h2>
 
+				<p>
+					Des de 1995, els Arreplegats hem portat els castells universitaris més enllà des de Barcelona, obrint camí amb fites inèdites i una colla que es renova cada curs.
+				</p>
+
 				<h5>Els inicis</h5>
 				<p>
 					Fundats a la primavera de 1995, els Arreplegats de la Zona Universitària vam ser la segona colla castellera universitària en aparèixer. Ja des del primer moment vam apostar per només castells complets, sempre amb acotxador i enxaneta. El mateix maig del 1995 es va carregar el primer pilar de quatre, i a inicis de l'any següent van arribar els primers castells de sis: 4 de 6 descarregat i 3 de 6 carregat.

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -36,6 +36,12 @@ class Home extends Component {
 				))
 			}
 			<section style={{paddingTop: `2rem`}}>
+				<h4>Colla castellera universitària de Barcelona</h4>
+				<p>
+					Els Arreplegats de la Zona Universitària som una colla castellera universitària de Barcelona. Assagem a la UPC, fem castells amb estudiants i mantenim viu l'esperit casteller dins la vida universitària.
+				</p>
+			</section>
+			<section>
 				<div className="floating-titles">
 					<h4>Els millors castells</h4>
 					<NavLink to="/millors-castells">Descobreix-los tots!</NavLink>

--- a/src/pages/MillorsCastells.js
+++ b/src/pages/MillorsCastells.js
@@ -8,6 +8,10 @@ class MillorsCastells extends Component {
 			<section>
 				<h2>Millors Castells</h2>
 
+				<p>
+					Aquesta selecció recull els castells més destacats dels Arreplegats, fites universitàries que expliquen el nivell assolit per la colla.
+				</p>
+
 				<div className="top-gallery">
 					{
 						Object.values(castells_map).map((e, i) => {

--- a/src/pages/QuiSom.js
+++ b/src/pages/QuiSom.js
@@ -15,6 +15,10 @@ class QuiSom extends Component {
 		return (<>
 			<section>
 				<h2>Qui som?</h2>
+
+				<p>
+					Som els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona oberta a estudiants amb ganes de fer pinya, aprendre i compartir castells.
+				</p>
 				
 				<div className="dictionary-entry">
 					<h4>arreplegat -ada</h4>


### PR DESCRIPTION
## Summary
- Adds concise Catalan intro copy to the homepage and core SEO routes.
- Clarifies that Arreplegats are a university casteller group in Barcelona.
- Improves search-intent context for `qui-som`, `assajos`, `historia-de-la-colla`, `millors-castells`, and `contactar`.

## Test plan
- `npm run build`

Note: build still reports pre-existing `CastellsGame.js` unreachable-code warnings and an outdated Browserslist notice.

Made with [Cursor](https://cursor.com)