### PR TITLE
Generate static route entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "deploy": "gh-pages -d build",
     "start": "PUBLIC_URL='.' react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "node scripts/generate-route-entrypoints.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/scripts/generate-route-entrypoints.js
+++ b/scripts/generate-route-entrypoints.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = path.resolve(__dirname, "..");
+const buildDir = path.join(rootDir, "build");
+const indexHtmlPath = path.join(buildDir, "index.html");
+const castellsTopPath = path.join(rootDir, "src", "data", "castells-top.json");
+
+// Keep this list to public, stable routes that should deep-link on static hosts.
+// Utility, private, event-specific, and generated game-level routes stay on the
+// existing 404.html fallback until they are intentionally promoted.
+const publicRoutes = [
+  "/qui-som",
+  "/agenda",
+  "/assajos",
+  "/gralles-i-tabals",
+  "/vida-universitaria",
+  "/historia-de-la-colla",
+  "/llista-de-caps-de-colla",
+  "/llista-de-presidents",
+  "/els-castells-universitaris",
+  "/millors-castells",
+  "/millors-diades",
+  "/resum-historic",
+  "/llista-de-diades",
+  "/junta-directiva",
+  "/junta-tecnica",
+  "/comissio-genere-grup-treball",
+  "/patrocinadors",
+  "/fotografies",
+  "/videos",
+  "/musica",
+  "/estatuts",
+  "/reglament-regim-intern",
+  "/protocol-agressions",
+  "/jocs",
+  "/joc-castells",
+  "/sopa-de-lletres",
+  "/mots-encreuats",
+  "/memory",
+  "/penjat",
+  "/contactar",
+  "/parts-castell",
+];
+
+function getCastellRoutes() {
+  const castellsTop = JSON.parse(fs.readFileSync(castellsTopPath, "utf8"));
+
+  return Object.keys(castellsTop).map((slug) => `/castells/${slug}`);
+}
+
+function assertSafeRoute(route) {
+  if (!route.startsWith("/") || route.includes("..") || route.includes("?") || route.includes("#")) {
+    throw new Error(`Unsafe route entrypoint: ${route}`);
+  }
+
+  if (route === "/") {
+    throw new Error("Root route already uses build/index.html");
+  }
+}
+
+function getOutputPath(route) {
+  assertSafeRoute(route);
+
+  const routePath = route.replace(/^\/+|\/+$/g, "");
+  const outputDir = path.resolve(buildDir, routePath);
+
+  if (!outputDir.startsWith(`${buildDir}${path.sep}`)) {
+    throw new Error(`Route escapes build directory: ${route}`);
+  }
+
+  return path.join(outputDir, "index.html");
+}
+
+function main() {
+  if (!fs.existsSync(indexHtmlPath)) {
+    throw new Error("Cannot generate route entrypoints before build/index.html exists.");
+  }
+
+  const indexHtml = fs.readFileSync(indexHtmlPath);
+  const routes = [...new Set([...publicRoutes, ...getCastellRoutes()])];
+
+  for (const route of routes) {
+    const outputPath = getOutputPath(route);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, indexHtml);
+  }
+
+  console.log(`Generated ${routes.length} static route entrypoints.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds a postbuild script that copies the built app shell into static route entrypoints for public React routes.
- Includes stable public routes plus castell detail routes from `castells-top.json` so deep links can be served directly on static hosting.
- Leaves uncertain utility/private/event routes on the existing fallback behavior.

## Test plan
- `npm run build`
- Confirmed postbuild generated 42 static route entrypoints.
- Verified generated files for `/qui-som`, `/assajos`, `/historia-de-la-colla`, `/contactar`, and `/castells/4d8`.

Note: build still reports pre-existing `CastellsGame.js` unreachable-code warnings and an outdated Browserslist notice.

Made with [Cursor](https://cursor.com)