### PR TITLE
[codex] Fix route canonical metadata

### DIFF
--- a/scripts/generate-route-entrypoints.js
+++ b/scripts/generate-route-entrypoints.js
@@ -7,6 +7,7 @@ const rootDir = path.resolve(__dirname, "..");
 const buildDir = path.join(rootDir, "build");
 const indexHtmlPath = path.join(buildDir, "index.html");
 const castellsTopPath = path.join(rootDir, "src", "data", "castells-top.json");
+const siteUrl = "https://arreplegats.cat";
 
 // Keep this list to public, stable routes that should deep-link on static hosts.
 // Utility, private, event-specific, and generated game-level routes stay on the
@@ -74,21 +75,43 @@ function getOutputPath(route) {
   return path.join(outputDir, "index.html");
 }
 
+function getCanonicalUrl(route) {
+  assertSafeRoute(route);
+
+  return `${siteUrl}${route.replace(/\/?$/, "/")}`;
+}
+
+function setRouteUrlMeta(indexHtml, route) {
+  const canonicalUrl = getCanonicalUrl(route);
+
+  return indexHtml
+    .replace(/<link rel="canonical" href="[^"]*"\s*\/>/, `<link rel="canonical" href="${canonicalUrl}" />`)
+    .replace(/<meta property="og:url" content="[^"]*">/, `<meta property="og:url" content="${canonicalUrl}">`)
+    .replace(/<meta property="twitter:url" content="[^"]*">/, `<meta property="twitter:url" content="${canonicalUrl}">`);
+}
+
 function main() {
   if (!fs.existsSync(indexHtmlPath)) {
     throw new Error("Cannot generate route entrypoints before build/index.html exists.");
   }
 
-  const indexHtml = fs.readFileSync(indexHtmlPath);
+  const indexHtml = fs.readFileSync(indexHtmlPath, "utf8");
   const routes = [...new Set([...publicRoutes, ...getCastellRoutes()])];
 
   for (const route of routes) {
     const outputPath = getOutputPath(route);
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    fs.writeFileSync(outputPath, indexHtml);
+    fs.writeFileSync(outputPath, setRouteUrlMeta(indexHtml, route));
   }
 
   console.log(`Generated ${routes.length} static route entrypoints.`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  getCanonicalUrl,
+  setRouteUrlMeta,
+};

--- a/src/generateRouteEntrypoints.test.js
+++ b/src/generateRouteEntrypoints.test.js
@@ -1,0 +1,33 @@
+const {
+  getCanonicalUrl,
+  setRouteUrlMeta,
+} = require("../scripts/generate-route-entrypoints");
+
+const baseHtml = `
+  <link rel="canonical" href="https://arreplegats.cat/" />
+  <meta property="og:url" content="https://arreplegats.cat/">
+  <meta property="twitter:url" content="https://arreplegats.cat/">
+`;
+
+const minifiedHtml = '<link rel="canonical" href="https://arreplegats.cat/"/><meta property="og:url" content="https://arreplegats.cat/"><meta property="twitter:url" content="https://arreplegats.cat/">';
+
+describe("route entrypoint metadata", () => {
+  test("builds the canonical URL served by GitHub Pages for route entrypoints", () => {
+    expect(getCanonicalUrl("/qui-som")).toBe("https://arreplegats.cat/qui-som/");
+    expect(getCanonicalUrl("/castells/Td8fm")).toBe("https://arreplegats.cat/castells/Td8fm/");
+  });
+
+  test("replaces home URL metadata on generated route entrypoints", () => {
+    const routeHtml = setRouteUrlMeta(baseHtml, "/assajos");
+
+    expect(routeHtml).toContain('<link rel="canonical" href="https://arreplegats.cat/assajos/" />');
+    expect(routeHtml).toContain('<meta property="og:url" content="https://arreplegats.cat/assajos/">');
+    expect(routeHtml).toContain('<meta property="twitter:url" content="https://arreplegats.cat/assajos/">');
+  });
+
+  test("replaces canonical URLs in minified build HTML", () => {
+    const routeHtml = setRouteUrlMeta(minifiedHtml, "/contactar");
+
+    expect(routeHtml).toContain('<link rel="canonical" href="https://arreplegats.cat/contactar/" />');
+  });
+});


### PR DESCRIPTION
## What changed
- Updates generated static route entrypoints so each route gets its own canonical URL.
- Updates `og:url` and `twitter:url` alongside the canonical URL.
- Adds Jest coverage for generated route URL metadata, including minified build HTML.

## Why
The published route entrypoints were inheriting the homepage canonical and social URL, which could cause search engines and link previews to consolidate route-level pages into the homepage.

## Validation
- `npm test -- --watchAll=false`
- `npm run build`
- Verified `build/qui-som/index.html` contains `https://arreplegats.cat/qui-som/` for canonical, Open Graph URL, and Twitter URL.
