### PR TITLE
[codex] Use canonical sitemap URLs

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,111 +4,111 @@
     <loc>https://arreplegats.cat/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/qui-som</loc>
+    <loc>https://arreplegats.cat/qui-som/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/agenda</loc>
+    <loc>https://arreplegats.cat/agenda/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/assajos</loc>
+    <loc>https://arreplegats.cat/assajos/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/gralles-i-tabals</loc>
+    <loc>https://arreplegats.cat/gralles-i-tabals/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/vida-universitaria</loc>
+    <loc>https://arreplegats.cat/vida-universitaria/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/historia-de-la-colla</loc>
+    <loc>https://arreplegats.cat/historia-de-la-colla/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/llista-de-caps-de-colla</loc>
+    <loc>https://arreplegats.cat/llista-de-caps-de-colla/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/llista-de-presidents</loc>
+    <loc>https://arreplegats.cat/llista-de-presidents/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/els-castells-universitaris</loc>
+    <loc>https://arreplegats.cat/els-castells-universitaris/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/millors-castells</loc>
+    <loc>https://arreplegats.cat/millors-castells/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/Td8fm</loc>
+    <loc>https://arreplegats.cat/castells/Td8fm/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/Pd7fm</loc>
+    <loc>https://arreplegats.cat/castells/Pd7fm/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/4d8</loc>
+    <loc>https://arreplegats.cat/castells/4d8/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/3d8f</loc>
+    <loc>https://arreplegats.cat/castells/3d8f/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/9d7</loc>
+    <loc>https://arreplegats.cat/castells/9d7/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/4d7s</loc>
+    <loc>https://arreplegats.cat/castells/4d7s/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/3d7s</loc>
+    <loc>https://arreplegats.cat/castells/3d7s/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/3d7+4d7</loc>
+    <loc>https://arreplegats.cat/castells/3d7+4d7/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/10d7</loc>
+    <loc>https://arreplegats.cat/castells/10d7/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/5d7</loc>
+    <loc>https://arreplegats.cat/castells/5d7/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/castells/Vd6f</loc>
+    <loc>https://arreplegats.cat/castells/Vd6f/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/millors-diades</loc>
+    <loc>https://arreplegats.cat/millors-diades/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/resum-historic</loc>
+    <loc>https://arreplegats.cat/resum-historic/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/llista-de-diades</loc>
+    <loc>https://arreplegats.cat/llista-de-diades/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/junta-directiva</loc>
+    <loc>https://arreplegats.cat/junta-directiva/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/junta-tecnica</loc>
+    <loc>https://arreplegats.cat/junta-tecnica/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/comissio-genere-grup-treball</loc>
+    <loc>https://arreplegats.cat/comissio-genere-grup-treball/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/patrocinadors</loc>
+    <loc>https://arreplegats.cat/patrocinadors/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/fotografies</loc>
+    <loc>https://arreplegats.cat/fotografies/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/videos</loc>
+    <loc>https://arreplegats.cat/videos/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/musica</loc>
+    <loc>https://arreplegats.cat/musica/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/estatuts</loc>
+    <loc>https://arreplegats.cat/estatuts/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/reglament-regim-intern</loc>
+    <loc>https://arreplegats.cat/reglament-regim-intern/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/protocol-agressions</loc>
+    <loc>https://arreplegats.cat/protocol-agressions/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/jocs</loc>
+    <loc>https://arreplegats.cat/jocs/</loc>
   </url>
   <url>
-    <loc>https://arreplegats.cat/contactar</loc>
+    <loc>https://arreplegats.cat/contactar/</loc>
   </url>
 </urlset>

--- a/src/sitemap.test.js
+++ b/src/sitemap.test.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+const sitemapPath = path.join(__dirname, "..", "public", "sitemap.xml");
+
+function getSitemapUrls() {
+	const sitemap = fs.readFileSync(sitemapPath, "utf8");
+
+	return [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+}
+
+describe("sitemap URLs", () => {
+	test("uses canonical trailing-slash URLs served by GitHub Pages", () => {
+		const urls = getSitemapUrls();
+
+		expect(urls).toContain("https://arreplegats.cat/");
+		expect(urls).toContain("https://arreplegats.cat/qui-som/");
+		expect(urls).toContain("https://arreplegats.cat/castells/Td8fm/");
+
+		for (const url of urls) {
+			const pathname = new URL(url).pathname;
+
+			expect(pathname.endsWith("/")).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## What changed
- Updates `public/sitemap.xml` so every listed page uses the trailing-slash URL served directly by GitHub Pages.
- Adds Jest coverage to ensure sitemap URLs stay in canonical trailing-slash form.

## Why
The live site redirects most sitemap URLs from `/path` to `/path/`. Listing final URLs avoids unnecessary crawl hops and keeps the sitemap aligned with canonical route URLs.

## Validation
- `npm test -- --watchAll=false`
- `npm run build`
- Confirmed no `<loc>` entries are missing a trailing slash.
