### PR TITLE
[codex] Add route-specific metadata

### DIFF
--- a/src/components/TitleUpdater.js
+++ b/src/components/TitleUpdater.js
@@ -1,131 +1,188 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
+const DEFAULT_META = {
+	title: "Arreplegats",
+	description: "Web oficial dels Arreplegats de la Zona Universitària, colla castellera universitària de Barcelona.",
+};
+
+const ROUTE_META = {
+	"": {
+		title: "Inici - Arreplegats",
+		description: "Web oficial dels Arreplegats de la Zona Universitària: castells universitaris, assajos, agenda i vida de la colla.",
+	},
+	"qui-som": {
+		title: "Qui Som - Arreplegats",
+		description: "Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d'història.",
+	},
+	agenda: {
+		title: "Agenda - Arreplegats",
+		description: "Consulta l'agenda d'assajos, activitats i actuacions dels Arreplegats de la Zona Universitària.",
+	},
+	assajos: {
+		title: "Assajos - Arreplegats",
+		description: "Vine als assajos dels Arreplegats: dimarts i dijous al migdia a l'ETSEIB i dijous al vespre amb Castellers de Sants.",
+	},
+	"gralles-i-tabals": {
+		title: "Gralles i Tabals - Arreplegats",
+		description: "Descobreix el grup de gralles i tabals dels Arreplegats i la música que acompanya els castells universitaris.",
+	},
+	"vida-universitaria": {
+		title: "Vida Universitària - Arreplegats",
+		description: "Activitats, convivència i vida universitària al voltant de la colla castellera Arreplegats de la Zona Universitària.",
+	},
+	"historia-de-la-colla": {
+		title: "Història de la Colla - Arreplegats",
+		description: "Repàs de la història dels Arreplegats, des de la fundació el 1995 fins als grans castells universitaris.",
+	},
+	"llista-de-caps-de-colla": {
+		title: "Llista de Caps de Colla - Arreplegats",
+		description: "Llista històrica de caps de colla dels Arreplegats de la Zona Universitària.",
+	},
+	"llista-de-presidents": {
+		title: "Llista de Presidents - Arreplegats",
+		description: "Llista històrica de presidents i presidentes dels Arreplegats de la Zona Universitària.",
+	},
+	"els-castells-universitaris": {
+		title: "Els Castells Universitaris - Arreplegats",
+		description: "Història i evolució dels castells universitaris, amb els principals fets i colles del món casteller universitari.",
+	},
+	"millors-castells": {
+		title: "Millors Castells - Arreplegats",
+		description: "Consulta els millors castells descarregats i carregats pels Arreplegats de la Zona Universitària.",
+	},
+	castells: {
+		title: "Castell - Arreplegats",
+		description: "Fitxa d'un castell dels Arreplegats amb imatges, informació i context històric de la construcció.",
+	},
+	"millors-diades": {
+		title: "Millors Diades - Arreplegats",
+		description: "Rànquing de les millors diades dels Arreplegats segons les puntuacions del Baròmetre Universitari.",
+	},
+	"resum-historic": {
+		title: "Resum Històric - Arreplegats",
+		description: "Resum històric de temporades, castells i actuacions dels Arreplegats de la Zona Universitària.",
+	},
+	"llista-de-diades": {
+		title: "Llista de Diades - Arreplegats",
+		description: "Consulta la llista de diades i actuacions dels Arreplegats amb els castells de cada jornada.",
+	},
+	"junta-directiva": {
+		title: "Junta Directiva - Arreplegats",
+		description: "Equip de junta directiva dels Arreplegats de la Zona Universitària.",
+	},
+	"junta-tecnica": {
+		title: "Junta Tècnica - Arreplegats",
+		description: "Equip de junta tècnica dels Arreplegats de la Zona Universitària.",
+	},
+	"comissio-genere-grup-treball": {
+		title: "Comissió de Gènere - Arreplegats",
+		description: "Comissió de gènere i grup de treball dels Arreplegats de la Zona Universitària.",
+	},
+	patrocinadors: {
+		title: "Patrocinadors - Arreplegats",
+		description: "Patrocinadors, col·laboradors i entitats que donen suport als Arreplegats de la Zona Universitària.",
+	},
+	fotografies: {
+		title: "Fotografies - Arreplegats",
+		description: "Galeria fotogràfica dels Arreplegats de la Zona Universitària.",
+	},
+	videos: {
+		title: "Vídeos - Arreplegats",
+		description: "Vídeos de castells, actuacions i continguts dels Arreplegats de la Zona Universitària.",
+	},
+	musica: {
+		title: "Música - Arreplegats",
+		description: "Cançons, partitures i música dels Arreplegats de la Zona Universitària.",
+	},
+	estatuts: {
+		title: "Estatuts - Arreplegats",
+		description: "Estatuts vigents i documents històrics dels Arreplegats de la Zona Universitària.",
+	},
+	"reglament-regim-intern": {
+		title: "Reglament Règim Intern - Arreplegats",
+		description: "Reglament de règim intern dels Arreplegats de la Zona Universitària.",
+	},
+	"protocol-agressions": {
+		title: "Protocol Agressions - Arreplegats",
+		description: "Protocol d'agressions i documents de prevenció dels Arreplegats de la Zona Universitària.",
+	},
+	jocs: {
+		title: "Jocs - Arreplegats",
+		description: "Jocs i activitats interactives dels Arreplegats sobre castells i cultura de la colla.",
+	},
+	"sopa-de-lletres": {
+		title: "Sopa de Lletres - Arreplegats",
+		description: "Sopa de lletres dels Arreplegats amb vocabulari de castells i de la colla.",
+	},
+	"mots-encreuats": {
+		title: "Mots Encreuats - Arreplegats",
+		description: "Mots encreuats dels Arreplegats amb pistes sobre castells, música i vida universitària.",
+	},
+	memory: {
+		title: "Memory - Arreplegats",
+		description: "Joc de memory dels Arreplegats amb elements del món casteller universitari.",
+	},
+	penjat: {
+		title: "Penjat - Arreplegats",
+		description: "Joc del penjat dels Arreplegats amb paraules relacionades amb castells i la colla.",
+	},
+	contactar: {
+		title: "Contactar - Arreplegats",
+		description: "Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials.",
+	},
+	"barra-lliure": {
+		title: "Barra Lliure - Arreplegats",
+		description: "Pàgina de barra lliure dels Arreplegats de la Zona Universitària.",
+	},
+	"parts-castell": {
+		title: "Parts Castell - Arreplegats",
+		description: "Aprèn les parts principals d'un castell amb els Arreplegats de la Zona Universitària.",
+	},
+	"nit-fresca-per-ser-maig": {
+		title: "Una Nit de Maig - Arreplegats",
+		description: "Informació de l'esdeveniment Una Nit de Maig dels Arreplegats de la Zona Universitària.",
+	},
+	palette: {
+		title: "Palette - Arreplegats",
+		description: "Paleta de colors dels Arreplegats de la Zona Universitària.",
+	},
+	"joc-castells": {
+		title: "Joc Castells - Arreplegats",
+		description: "Joc de gestió castellera dels Arreplegats de la Zona Universitària.",
+	},
+};
+
+function setMetaContent(selector, content) {
+	const element = document.head.querySelector(selector);
+
+	if (element) {
+		element.setAttribute("content", content);
+	}
+}
+
+export function getRouteMeta(pathname) {
+	const firstWord = pathname.split("/")?.[1] || "";
+
+	return ROUTE_META[firstWord] || DEFAULT_META;
+}
+
 const TitleUpdater = () => {
-  const location = useLocation();
+	const location = useLocation();
 
-  useEffect(() => {
-    const path = location.pathname;
-    let title = "Arreplegats";
+	useEffect(() => {
+		const meta = getRouteMeta(location.pathname);
 
-    // Extract the first word after the slash
-    const firstWord = path.split("/")?.[1] || "";
+		document.title = meta.title;
+		setMetaContent('meta[name="title"]', meta.title);
+		setMetaContent('meta[name="description"]', meta.description);
+		setMetaContent('meta[property="og:title"]', meta.title);
+		setMetaContent('meta[property="og:description"]', meta.description);
+		setMetaContent('meta[property="twitter:title"]', meta.title);
+		setMetaContent('meta[property="twitter:description"]', meta.description);
+	}, [location]);
 
-    // Set the title based on the first word
-    switch (firstWord) {
-      case "":
-        title = "Inici - Arreplegats";
-        break;
-      case "qui-som":
-        title = "Qui Som - Arreplegats";
-        break;
-      case "agenda":
-        title = "Agenda - Arreplegats";
-        break;
-      case "assajos":
-        title = "Assajos - Arreplegats";
-        break;
-      case "gralles-i-tabals":
-        title = "Gralles i Tabals - Arreplegats";
-        break;
-      case "vida-universitaria":
-        title = "Vida Universitària - Arreplegats";
-        break;
-      case "historia-de-la-colla":
-        title = "Història de la Colla - Arreplegats";
-        break;
-      case "llista-de-caps-de-colla":
-        title = "Llista de Caps de Colla - Arreplegats";
-        break;
-      case "llista-de-presidents":
-        title = "Llista de Presidents - Arreplegats";
-        break;
-      case "els-castells-universitaris":
-        title = "Els Castells Universitaris - Arreplegats";
-        break;
-      case "millors-castells":
-        title = "Millors Castells - Arreplegats";
-        break;
-      case "castells":
-        title = "Castell - Arreplegats";
-        break;
-      case "millors-diades":
-        title = "Millors Diades - Arreplegats";
-        break;
-      case "resum-historic":
-        title = "Resum Històric - Arreplegats";
-        break;
-      case "llista-de-diades":
-        title = "Llista de Diades - Arreplegats";
-        break;
-      case "junta-directiva":
-        title = "Junta Directiva - Arreplegats";
-        break;
-      case "junta-tecnica":
-        title = "Junta Tècnica - Arreplegats";
-        break;
-      case "patrocinadors":
-        title = "Patrocinadors - Arreplegats";
-        break;
-      case "fotografies":
-        title = "Fotografies - Arreplegats";
-        break;
-      case "videos":
-        title = "Vídeos - Arreplegats";
-        break;
-      case "musica":
-        title = "Música - Arreplegats";
-        break;
-      case "estatuts":
-        title = "Estatuts - Arreplegats";
-        break;
-      case "reglament-regim-intern":
-        title = "Reglament Règim Intern - Arreplegats";
-        break;
-      case "protocol-agressions":
-        title = "Protocol Agressions - Arreplegats";
-        break;
-      case "jocs":
-        title = "Jocs - Arreplegats";
-        break;
-      case "sopa-de-lletres":
-        title = "Sopa de Lletres - Arreplegats";
-        break;
-      case "mots-encreuats":
-        title = "Mots Encreuats - Arreplegats";
-        break;
-      case "memory":
-        title = "Memory - Arreplegats";
-        break;
-      case "penjat":
-        title = "Penjat - Arreplegats";
-        break;
-      case "contactar":
-        title = "Contactar - Arreplegats";
-        break;
-      case "barra-lliure":
-        title = "Barra Lliure - Arreplegats";
-        break;
-      case "parts-castell":
-        title = "Parts Castell - Arreplegats";
-        break;
-      case "nit-fresca-per-ser-maig":
-        title = "Una Nit de Maig - Arreplegats";
-        break;
-      case "palette":
-        title = "Palette - Arreplegats";
-        break;
-      case "joc-castells":
-        title = "Joc Castells - Arreplegats";
-        break;
-      default:
-        title = "Arreplegats";
-    }
-
-    document.title = title;
-  }, [location]);
-
-  return null;
+	return null;
 };
 
 export default TitleUpdater;

--- a/src/components/TitleUpdater.test.js
+++ b/src/components/TitleUpdater.test.js
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TitleUpdater, { getRouteMeta } from "./TitleUpdater";
+
+function addMetaTag(attributes) {
+	const element = document.createElement("meta");
+
+	for (const [name, value] of Object.entries(attributes)) {
+		element.setAttribute(name, value);
+	}
+
+	document.head.appendChild(element);
+}
+
+function renderTitleUpdater(pathname) {
+	render(
+		<MemoryRouter initialEntries={[pathname]}>
+			<TitleUpdater />
+		</MemoryRouter>
+	);
+}
+
+describe("TitleUpdater", () => {
+	beforeEach(() => {
+		document.head.innerHTML = "";
+		document.title = "";
+		addMetaTag({ name: "title", content: "" });
+		addMetaTag({ name: "description", content: "" });
+		addMetaTag({ property: "og:title", content: "" });
+		addMetaTag({ property: "og:description", content: "" });
+		addMetaTag({ property: "twitter:title", content: "" });
+		addMetaTag({ property: "twitter:description", content: "" });
+	});
+
+	test("returns route-specific metadata for important pages", () => {
+		expect(getRouteMeta("/assajos")).toEqual({
+			title: "Assajos - Arreplegats",
+			description: "Vine als assajos dels Arreplegats: dimarts i dijous al migdia a l'ETSEIB i dijous al vespre amb Castellers de Sants.",
+		});
+	});
+
+	test("updates document title and description meta tags for the active route", () => {
+		renderTitleUpdater("/qui-som");
+
+		expect(document.title).toBe("Qui Som - Arreplegats");
+		expect(document.head.querySelector('meta[name="title"]')).toHaveAttribute("content", "Qui Som - Arreplegats");
+		expect(document.head.querySelector('meta[name="description"]')).toHaveAttribute(
+			"content",
+			"Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d'història."
+		);
+	});
+
+	test("keeps Open Graph and Twitter metadata aligned with route metadata", () => {
+		renderTitleUpdater("/contactar");
+
+		expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", "Contactar - Arreplegats");
+		expect(document.head.querySelector('meta[property="twitter:title"]')).toHaveAttribute("content", "Contactar - Arreplegats");
+		expect(document.head.querySelector('meta[property="og:description"]')).toHaveAttribute(
+			"content",
+			"Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials."
+		);
+		expect(document.head.querySelector('meta[property="twitter:description"]')).toHaveAttribute(
+			"content",
+			"Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials."
+		);
+	});
+});


### PR DESCRIPTION
## What changed
- Replaces the title-only route switch with a route metadata map.
- Updates document title plus `meta[name=title]`, meta description, Open Graph title/description, and Twitter title/description on route changes.
- Adds tests for route metadata lookup and head updates.

## Why
The app had page-specific document titles, but every route kept the homepage meta description and social title/description. This gives key pages distinct search and sharing metadata after render.

## Validation
- `npm test -- --watchAll=false`
- `npm run build`
- Build completed with +929 B gzip on the main JS bundle.
