### PR TITLE
[codex] Promote key page titles to h1

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -175,6 +175,10 @@ h2 {
 	font-size: 2.441rem;
 }
 
+.page-title {
+	font-size: 2.441rem;
+}
+
 h3 {
 	font-size: 1.953rem;
 }

--- a/src/pages/Assajos.js
+++ b/src/pages/Assajos.js
@@ -4,7 +4,7 @@ class Assajos extends Component {
 	render() {
 		return (<>
 			<section>
-				<h2>Assajos</h2>
+				<h1 className="page-title">Assajos</h1>
 
 				<p>
 					Els bons castells no surten del no-res: s'han d'assajar. Ens reunim dos dies a la setmana per fer història assaig a assaig.

--- a/src/pages/Contactar.js
+++ b/src/pages/Contactar.js
@@ -4,7 +4,7 @@ class Contactar extends Component {
 	render() {
 		return (<>
 			<section>
-				<h2>Contacta'ns</h2>
+				<h1 className="page-title">Contacta'ns</h1>
 
 				<ul className="contact-info">
 					<li><img src="/font-awesome/mail.svg" alt="Email" style={{ width: '14px', height: '14px' }} /> Correu electrònic: <a href="mailto:junta.arreplegats@gmail.com">junta.arreplegats@gmail.com</a></li>

--- a/src/pages/HistoriaDeLaColla.js
+++ b/src/pages/HistoriaDeLaColla.js
@@ -32,7 +32,7 @@ class HistoriaDeLaColla extends Component {
 
 		return (<>
 			<section className="historia">
-				<h2>Història de la colla</h2>
+				<h1 className="page-title">Història de la colla</h1>
 
 				<h5>Els inicis</h5>
 				<p>

--- a/src/pages/MillorsCastells.js
+++ b/src/pages/MillorsCastells.js
@@ -6,7 +6,7 @@ class MillorsCastells extends Component {
 	render() {
 		return (<>
 			<section>
-				<h2>Millors Castells</h2>
+				<h1 className="page-title">Millors Castells</h1>
 
 				<div className="top-gallery">
 					{

--- a/src/pages/PublicPageHeadings.test.js
+++ b/src/pages/PublicPageHeadings.test.js
@@ -1,0 +1,30 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Assajos from "./Assajos";
+import Contactar from "./Contactar";
+import HistoriaDeLaColla from "./HistoriaDeLaColla";
+import MillorsCastells from "./MillorsCastells";
+import QuiSom from "./QuiSom";
+
+function renderPage(Page) {
+	render(
+		<MemoryRouter>
+			<Page />
+		</MemoryRouter>
+	);
+}
+
+describe("public page headings", () => {
+	test.each([
+		[Assajos, "Assajos"],
+		[Contactar, "Contacta'ns"],
+		[HistoriaDeLaColla, "Història de la colla"],
+		[MillorsCastells, "Millors Castells"],
+		[QuiSom, "Qui som?"],
+	])("%s renders its visible page title as an h1", (Page, title) => {
+		renderPage(Page);
+
+		expect(screen.getByRole("heading", { level: 1, name: title })).toHaveClass("page-title");
+	});
+});

--- a/src/pages/QuiSom.js
+++ b/src/pages/QuiSom.js
@@ -14,7 +14,7 @@ class QuiSom extends Component {
 
 		return (<>
 			<section>
-				<h2>Qui som?</h2>
+				<h1 className="page-title">Qui som?</h1>
 				
 				<div className="dictionary-entry">
 					<h4>arreplegat -ada</h4>


### PR DESCRIPTION
## What changed
- Promotes the visible page titles for key public pages from `h2` to `h1`.
- Adds a `.page-title` class so the visual scale remains consistent with the previous design.
- Adds tests that assert the audited pages expose their main title as a level-one heading.

## Why
The SEO audit found internal pages starting their visible content with `h2`, while the only `h1` could come from the shared fallback. These pages now expose a route-specific visible `h1` for crawlers and assistive technology.

## Validation
- `npm test -- --watchAll=false`
- `npm run build`
- `git diff --check`
