### PR TITLE
[codex] Improve noscript fallback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -105,6 +105,19 @@
       #root:not(:empty) + .azu-seo-fallback {
         display: none;
       }
+
+      .azu-noscript {
+        max-width: 960px;
+        margin: 1rem auto 0;
+        padding: 1rem 1.25rem 0;
+        color: #1f1f1f;
+        font-family: Roboto, Arial, sans-serif;
+        line-height: 1.55;
+      }
+
+      .azu-noscript a {
+        color: #8a1538;
+      }
     </style>
     <title>Arreplegats de la Zona Universitària | Colla Castellera</title>
 
@@ -137,7 +150,18 @@
     </script>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>
+      <section class="azu-noscript" aria-label="Avís sobre JavaScript">
+        <strong>La web interactiva dels Arreplegats funciona millor amb JavaScript activat.</strong>
+        <p>
+          També pots consultar el contingut principal més avall o anar directament a
+          <a href="/assajos">assajos</a>,
+          <a href="/qui-som">qui som</a>,
+          <a href="/historia-de-la-colla">història de la colla</a> o
+          <a href="/contactar">contactar</a>.
+        </p>
+      </section>
+    </noscript>
     <div id="root"></div>
     <section class="azu-seo-fallback" aria-label="Contingut principal dels Arreplegats">
       <h1>Arreplegats de la Zona Universitària</h1>

--- a/src/noscriptFallback.test.js
+++ b/src/noscriptFallback.test.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+const indexHtmlPath = path.join(__dirname, "..", "public", "index.html");
+
+function getIndexHtml() {
+	return fs.readFileSync(indexHtmlPath, "utf8");
+}
+
+describe("noscript fallback", () => {
+	test("uses useful Catalan content instead of the default app-shell message", () => {
+		const indexHtml = getIndexHtml();
+
+		expect(indexHtml).not.toContain("You need to enable JavaScript to run this app.");
+		expect(indexHtml).toContain("La web interactiva dels Arreplegats funciona millor amb JavaScript activat.");
+		expect(indexHtml).toContain('<a href="/assajos">assajos</a>');
+		expect(indexHtml).toContain('<a href="/contactar">contactar</a>');
+	});
+});


### PR DESCRIPTION
## What changed
- Replaces the default English CRA `noscript` message with useful Catalan content.
- Links directly to the main fallback destinations: assajos, qui som, història, and contactar.
- Adds tests to prevent the default app-shell message from returning.

## Why
The page already includes an SEO fallback, but users and crawlers without JavaScript still saw a generic app-shell warning first. This makes the no-JS experience consistent with the site content and language.

## Validation
- `npm test -- --watchAll=false`
- `npm run build`
- `git diff --check`
