### PR TITLE
[codex] Fix navbar logo aspect ratio

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -391,6 +391,7 @@ Navbar
 
 .nav-header img {
 	margin-right: 0.7rem;
+	width: auto;
 	height: 3rem;
 	user-select: none;
 }


### PR DESCRIPTION
## What changed

- Preserve the navbar logo aspect ratio by letting its width auto-scale when the CSS fixes its height to `3rem`.

## Why

The logo image has a natural `96x93` ratio, but the rendered element kept the HTML `width="96"` while CSS forced `height: 3rem`, stretching it horizontally in the top-left navbar.

## Impact

The logo now renders at the intended proportions without changing the navbar layout or asset files.

## Validation

- `npm test -- --watchAll=false --runTestsByPath src/homeImageAssets.test.js`
- `npm run build`
- Visual check on `http://127.0.0.1:3000` confirmed the rendered ratio matches the image ratio.
