### PR TITLE
[codex] Use canonical internal link URLs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -125,10 +125,10 @@
         <strong>La web interactiva dels Arreplegats funciona millor amb JavaScript activat.</strong>
         <p>
           També pots anar directament a
-          <a href="/assajos">assajos</a>,
-          <a href="/qui-som">qui som</a>,
-          <a href="/historia-de-la-colla">història de la colla</a> o
-          <a href="/contactar">contactar</a>.
+          <a href="/assajos/">assajos</a>,
+          <a href="/qui-som/">qui som</a>,
+          <a href="/historia-de-la-colla/">història de la colla</a> o
+          <a href="/contactar/">contactar</a>.
         </p>
       </section>
     </noscript>

--- a/src/components/CastellCard.js
+++ b/src/components/CastellCard.js
@@ -13,7 +13,7 @@ class CastellCard extends Component {
 			<div className="castell-card" style={{backgroundImage: `url(${backgroundImage})`}}>
 				<div className="castell-link">
 					<p>{this.props.name}</p>
-					<NavLink to={`/castells/${this.props.notation}`}>Saber-ne més</NavLink>
+					<NavLink to={`/castells/${this.props.notation}/`}>Saber-ne més</NavLink>
 				</div>
 			</div>
 		);

--- a/src/components/CastellCard.test.js
+++ b/src/components/CastellCard.test.js
@@ -18,5 +18,6 @@ describe("CastellCard", () => {
 		expect(screen.getByText("Torre de 8 amb folre i manilles").closest(".castell-card")).toHaveStyle({
 			backgroundImage: "url(/images/2d8fm-arreplegats-2016.webp)",
 		});
+		expect(screen.getByRole("link", { name: "Saber-ne més" })).toHaveAttribute("href", "/castells/Td8fm/");
 	});
 });

--- a/src/components/HomeHero.js
+++ b/src/components/HomeHero.js
@@ -3,9 +3,9 @@ import { NavLink } from "react-router-dom";
 import { buildHeroSrcSet, buildHeroWebpSrcSet, getHeroFallbackImage, HOME_HERO_IMAGES } from "../data/homeHeroImages";
 
 const HERO_LINKS = [
-	{ to: "/assajos", label: "UNEIX-T'HI" },
-	{ to: "/agenda", label: "AGENDA" },
-	{ to: "/contactar", label: "CONTACTA'NS!" },
+	{ to: "/assajos/", label: "UNEIX-T'HI" },
+	{ to: "/agenda/", label: "AGENDA" },
+	{ to: "/contactar/", label: "CONTACTA'NS!" },
 ];
 
 function HomeHero({ images = HOME_HERO_IMAGES }) {

--- a/src/components/HomeHero.test.js
+++ b/src/components/HomeHero.test.js
@@ -26,8 +26,8 @@ describe("HomeHero", () => {
 		expect(heroImage).toHaveAttribute("width", String(fallbackImage.width));
 		expect(heroImage).toHaveAttribute("height", String(fallbackImage.height));
 		expect(heroImage).toHaveAttribute("fetchpriority", "high");
-		expect(screen.getByRole("link", { name: "UNEIX-T'HI" })).toHaveAttribute("href", "/assajos");
-		expect(screen.getByRole("link", { name: "AGENDA" })).toHaveAttribute("href", "/agenda");
-		expect(screen.getByRole("link", { name: "CONTACTA'NS!" })).toHaveAttribute("href", "/contactar");
+		expect(screen.getByRole("link", { name: "UNEIX-T'HI" })).toHaveAttribute("href", "/assajos/");
+		expect(screen.getByRole("link", { name: "AGENDA" })).toHaveAttribute("href", "/agenda/");
+		expect(screen.getByRole("link", { name: "CONTACTA'NS!" })).toHaveAttribute("href", "/contactar/");
 	});
 });

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -71,44 +71,44 @@ class Navbar extends Component {
 								<div className="sub-menu">
 									<h4 className="sub-menu-title">La colla</h4>
 									<ul>
-										<li><NavLink to="/qui-som">Qui som?</NavLink></li>
-										{/* <li><NavLink to="/agenda">Agenda</NavLink></li> */}
-										{/* <li><NavLink to="/assajos">Assajos</NavLink></li> */}
-										<li><NavLink to="/gralles-i-tabals">Gralles i tabals</NavLink></li>
-										<li><NavLink to="/vida-universitaria">Vida universitària</NavLink></li>
+										<li><NavLink to="/qui-som/">Qui som?</NavLink></li>
+										{/* <li><NavLink to="/agenda/">Agenda</NavLink></li> */}
+										{/* <li><NavLink to="/assajos/">Assajos</NavLink></li> */}
+										<li><NavLink to="/gralles-i-tabals/">Gralles i tabals</NavLink></li>
+										<li><NavLink to="/vida-universitaria/">Vida universitària</NavLink></li>
 									</ul>
 								</div>
 								<div className="sub-menu">
 									<h4 className="sub-menu-title">Història</h4>
 									<ul>
-										<li><NavLink to="/historia-de-la-colla">Història de la colla</NavLink></li>
-										<li><NavLink to="/llista-de-caps-de-colla">Llista de caps de colla</NavLink></li>
-										<li><NavLink to="/llista-de-presidents">Llista de presidents</NavLink></li>
-										<li><NavLink to="/els-castells-universitaris">Els castells universitaris</NavLink></li>
+										<li><NavLink to="/historia-de-la-colla/">Història de la colla</NavLink></li>
+										<li><NavLink to="/llista-de-caps-de-colla/">Llista de caps de colla</NavLink></li>
+										<li><NavLink to="/llista-de-presidents/">Llista de presidents</NavLink></li>
+										<li><NavLink to="/els-castells-universitaris/">Els castells universitaris</NavLink></li>
 									</ul>
 								</div>
 								<div className="sub-menu">
 									<h4 className="sub-menu-title">Castells</h4>
 									<ul>
-										<li><NavLink to="/millors-castells">Millors castells</NavLink></li>
-										<li><NavLink to="/millors-diades">Millors diades</NavLink></li>
-										<li><NavLink to="/resum-historic">Resum històric</NavLink></li>
-										<li><NavLink to="/llista-de-diades">Llista de diades</NavLink></li>
+										<li><NavLink to="/millors-castells/">Millors castells</NavLink></li>
+										<li><NavLink to="/millors-diades/">Millors diades</NavLink></li>
+										<li><NavLink to="/resum-historic/">Resum històric</NavLink></li>
+										<li><NavLink to="/llista-de-diades/">Llista de diades</NavLink></li>
 									</ul>
 								</div>
 								<div className="sub-menu">
 									<h4 className="sub-menu-title">Organització</h4>
 									<ul>
-										<li><NavLink to="/junta-directiva">Junta directiva</NavLink></li>
-										<li><NavLink to="/junta-tecnica">Junta tècnica</NavLink></li>
-										<li><NavLink to="/comissio-genere-grup-treball">Comissió de gènere i grup treball</NavLink></li>
+										<li><NavLink to="/junta-directiva/">Junta directiva</NavLink></li>
+										<li><NavLink to="/junta-tecnica/">Junta tècnica</NavLink></li>
+										<li><NavLink to="/comissio-genere-grup-treball/">Comissió de gènere i grup treball</NavLink></li>
 									</ul>
 								</div>
 								<div className="sub-menu">
 									<h4 className="sub-menu-title">Uneix-t'hi</h4>
 									<ul>
-										<li><NavLink to="/assajos">Vine a fer castells!</NavLink></li>
-										<li><NavLink to="/patrocinadors">Patrocinadors</NavLink></li>
+										<li><NavLink to="/assajos/">Vine a fer castells!</NavLink></li>
+										<li><NavLink to="/patrocinadors/">Patrocinadors</NavLink></li>
 									</ul>
 								</div>
 							</div>
@@ -118,9 +118,9 @@ class Navbar extends Component {
 							<div id="media" className="sub-menus">
 								<div className="sub-menu">
 									<ul>
-										<li><NavLink to="/fotografies">Fotografies</NavLink></li>
-										<li><NavLink to="/videos">Vídeos</NavLink></li>
-										<li><NavLink to="/musica">Música</NavLink></li>
+										<li><NavLink to="/fotografies/">Fotografies</NavLink></li>
+										<li><NavLink to="/videos/">Vídeos</NavLink></li>
+										<li><NavLink to="/musica/">Música</NavLink></li>
 									</ul>
 								</div>
 							</div>
@@ -130,17 +130,17 @@ class Navbar extends Component {
 							<div id="legal" className="sub-menus">
 								<div className="sub-menu">
 									<ul>
-										<li><NavLink to="/estatuts">Estatuts (2024)</NavLink></li>
-										<li><NavLink to="/reglament-regim-intern">Reglament de Règim Intern (2023)</NavLink></li>
-										<li><NavLink to="/protocol-agressions">Protocol d'agressions (2022)</NavLink></li>
+										<li><NavLink to="/estatuts/">Estatuts (2024)</NavLink></li>
+										<li><NavLink to="/reglament-regim-intern/">Reglament de Règim Intern (2023)</NavLink></li>
+										<li><NavLink to="/protocol-agressions/">Protocol d'agressions (2022)</NavLink></li>
 									</ul>
 								</div>
 							</div>
 						</li>
-						<li className="nav-link"><NavLink to="/jocs"><span>Jocs</span></NavLink></li>
-						<li className="nav-link"><NavLink to="/contactar"><span>Contacta'ns</span></NavLink></li>
+						<li className="nav-link"><NavLink to="/jocs/"><span>Jocs</span></NavLink></li>
+						<li className="nav-link"><NavLink to="/contactar/"><span>Contacta'ns</span></NavLink></li>
 						{/* <li className="nav-link"><a href="https://contractacions.arreplegats.cat" target="_blank" rel="noreferrer"><span>Contractacions</span></a></li> */}
-						<li className="nav-link join-btn"><NavLink to="/assajos"><span>Uneix-t'hi</span></NavLink></li>
+						<li className="nav-link join-btn"><NavLink to="/assajos/"><span>Uneix-t'hi</span></NavLink></li>
 					</ul>
 				</div>
 			</nav>

--- a/src/components/Navbar.test.js
+++ b/src/components/Navbar.test.js
@@ -1,0 +1,26 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Navbar from "./Navbar";
+
+describe("Navbar", () => {
+	test("uses canonical trailing slashes for internal page links", () => {
+		render(
+			<MemoryRouter>
+				<Navbar />
+			</MemoryRouter>
+		);
+
+		const internalLinks = screen
+			.getAllByRole("link")
+			.map((link) => link.getAttribute("href"))
+			.filter((href) => href && href.startsWith("/") && href !== "/");
+
+		expect(internalLinks).toContain("/qui-som/");
+		expect(internalLinks).toContain("/assajos/");
+		expect(internalLinks).toContain("/contactar/");
+		for (const href of internalLinks) {
+			expect(href).toMatch(/\/$/);
+		}
+	});
+});

--- a/src/components/ResumCard.js
+++ b/src/components/ResumCard.js
@@ -18,7 +18,7 @@ class ResumCard extends Component {
 				<div className="resum-card-inner">
 					{card}
 					<div className="resum-card-back">
-						<NavLink to={`/castells/${this.props.castell}`}>
+						<NavLink to={`/castells/${this.props.castell}/`}>
 							<span>Saber-ne més</span>
 						</NavLink>
 					</div>

--- a/src/noscriptFallback.test.js
+++ b/src/noscriptFallback.test.js
@@ -13,8 +13,19 @@ describe("noscript fallback", () => {
 
 		expect(indexHtml).not.toContain("You need to enable JavaScript to run this app.");
 		expect(indexHtml).toContain("La web interactiva dels Arreplegats funciona millor amb JavaScript activat.");
-		expect(indexHtml).toContain('<a href="/assajos">assajos</a>');
-		expect(indexHtml).toContain('<a href="/contactar">contactar</a>');
+		expect(indexHtml).toContain('<a href="/assajos/">assajos</a>');
+		expect(indexHtml).toContain('<a href="/contactar/">contactar</a>');
+	});
+
+	test("uses canonical trailing slash URLs for fallback internal links", () => {
+		const indexHtml = getIndexHtml();
+		const internalLinks = [...indexHtml.matchAll(/<a\s+href="(\/[^"]*)"/g)]
+			.map((match) => match[1])
+			.filter((href) => href !== "/" && !href.startsWith("/uploads/"));
+
+		for (const href of internalLinks) {
+			expect(href).toMatch(/\/$/);
+		}
 	});
 
 	test("does not ship a duplicate SEO fallback outside the React root", () => {

--- a/src/pages/ComissioGenereGrupTreball.js
+++ b/src/pages/ComissioGenereGrupTreball.js
@@ -22,7 +22,7 @@ class ComissioGenereGrupTreball extends Component {
 		return (<>
 			<section>
 				<h2>Comissió de gènere i grup treball</h2>
-				{ any && <p className="junta-message"><span>Atenció!</span> Estàs consultant la comissió d'una temporada anterior. Per veure'n l'actual fes click <NavLink to="/comissio-genere-grup-treball">aquí</NavLink>.</p> }
+				{ any && <p className="junta-message"><span>Atenció!</span> Estàs consultant la comissió d'una temporada anterior. Per veure'n l'actual fes click <NavLink to="/comissio-genere-grup-treball/">aquí</NavLink>.</p> }
 
 				<p>
 					La Comissió de Gènere té com a objectiu promoure la igualtat de gènere i prevenir qualsevol tipus de discriminació dins la colla. Treballa per crear un entorn segur i respectuós per a tothom.
@@ -37,10 +37,10 @@ class ComissioGenereGrupTreball extends Component {
 					<div className="junta-year-wrap">
 						{
 							Object.keys(junta.anteriors).map((y, i) => {
-								return <NavLink className={`junta-year ${junta_temporada === junta.anteriors[y]}`} to={`/comissio-genere-grup-treball/${y}`} key={`year-${i}`}>{y}</NavLink>;
+								return <NavLink className={`junta-year ${junta_temporada === junta.anteriors[y]}`} to={`/comissio-genere-grup-treball/${y}/`} key={`year-${i}`}>{y}</NavLink>;
 							})
 						}
-						<NavLink className={`junta-year ${junta_temporada === junta.actual}`} to="/comissio-genere-grup-treball">ACTUAL</NavLink>
+						<NavLink className={`junta-year ${junta_temporada === junta.actual}`} to="/comissio-genere-grup-treball/">ACTUAL</NavLink>
 					</div>
 				</>}
 

--- a/src/pages/GrallesTabals.js
+++ b/src/pages/GrallesTabals.js
@@ -22,7 +22,7 @@ class GrallesTabals extends Component {
 				</p>
 				
 				<div className="read-more">
-					<NavLink to="/contactar">CONTACTA'NS</NavLink>
+					<NavLink to="/contactar/">CONTACTA'NS</NavLink>
 				</div>
 			</section>
 		</>);

--- a/src/pages/HistoriaDeLaColla.js
+++ b/src/pages/HistoriaDeLaColla.js
@@ -45,7 +45,7 @@ class HistoriaDeLaColla extends Component {
 					La temporada següent, vam experimentar un avenç brutal, carregant i després descarregant la primera torre de 6, descarregant el tres de 6 per sota, i acabant l'èxtasi amb el primer 4 de 7 carregat. Provar un castell de 7 pisos era un salt al desconegut, una nova dimensió en el món casteller universitari. Aquell any també es va descarregar el primer pilar de 5, i es va aconseguir carregar del 3 de 6 net carregat, que obria les portes al 3 de 7.
 				</p>
 				<p>
-					Aquest castell, el 3 de 7, es va fer esperar més, sent el primer descarregat al final de la temporada 2000-2001. El següent any, es va carregar el primer 4 de 7 amb l'agulla, descarregat un any després. La temporada 2003-2004 va acabar amb dos nous castells: el <NavLink to="/castells/5d7">5 de 7</NavLink> i la torre de 7 amb folre, ambdós descarregats. El següent castell amb folre va arribar durant la temporada 2006-2007, quan vam carregar el primer pilar de 6 amb folre de la història castellera universitària. Aquest castell finalment es va descarregar a les acaballes de la temporada 2007-2008, en la Diada de Primavera dels Ganàpies de l'Autònoma.
+					Aquest castell, el 3 de 7, es va fer esperar més, sent el primer descarregat al final de la temporada 2000-2001. El següent any, es va carregar el primer 4 de 7 amb l'agulla, descarregat un any després. La temporada 2003-2004 va acabar amb dos nous castells: el <NavLink to="/castells/5d7/">5 de 7</NavLink> i la torre de 7 amb folre, ambdós descarregats. El següent castell amb folre va arribar durant la temporada 2006-2007, quan vam carregar el primer pilar de 6 amb folre de la història castellera universitària. Aquest castell finalment es va descarregar a les acaballes de la temporada 2007-2008, en la Diada de Primavera dels Ganàpies de l'Autònoma.
 				</p>
 			</section>
 			{
@@ -56,13 +56,13 @@ class HistoriaDeLaColla extends Component {
 			<section className="historia">
 				<h5>Els únics que ho poden fer</h5>
 				<p>
-					La temporada 2008-2009 va estar marcada pel domini absolut de la gamma de castells de set i de set i mig, duts a diverses places. Aquest alt nivell va permetre a la colla assolir a finals de temporada l'èxit més sonat, descarregant en la mateixa actuació dos castells universitaris inèdits: el <NavLink to="/castells/3d7s">3 de 7 per sota</NavLink> i el <NavLink to="/castells/4d8">4 de 8</NavLink>. Aquest últim es va convertir en el primer castell de vuit pisos fet mai per una colla castellera universitària.
+					La temporada 2008-2009 va estar marcada pel domini absolut de la gamma de castells de set i de set i mig, duts a diverses places. Aquest alt nivell va permetre a la colla assolir a finals de temporada l'èxit més sonat, descarregant en la mateixa actuació dos castells universitaris inèdits: el <NavLink to="/castells/3d7s/">3 de 7 per sota</NavLink> i el <NavLink to="/castells/4d8/">4 de 8</NavLink>. Aquest últim es va convertir en el primer castell de vuit pisos fet mai per una colla castellera universitària.
 				</p>
 				<p>
-					La gran revolució va venir el 2010, quan ens atrevíem a portar a plaça les primeres manilles universitàries de la mà del <NavLink to="/castells/Pd7fm">pilar de 7 amb folre i manilles</NavLink>. El vam haver de deixar en carregat, però no ens vam rendir, i el maig del 2013 el descarregàvem finalment.
+					La gran revolució va venir el 2010, quan ens atrevíem a portar a plaça les primeres manilles universitàries de la mà del <NavLink to="/castells/Pd7fm/">pilar de 7 amb folre i manilles</NavLink>. El vam haver de deixar en carregat, però no ens vam rendir, i el maig del 2013 el descarregàvem finalment.
 				</p>
 				<p>
-					No gaire més tard, l'hivern del 2014, vam portar a la Diada dels Ganàpies de la UAB el primer <NavLink to="/castells/3d8f">3 de 8 amb folre</NavLink> del món universitari, que veia com es feia història un altre cop en descarregar aquest castell fins aleshores inèdit. Aquell mateix desembre, pel nostre 19è Aniversari, sorpreníem el món sencer obrint plaça amb el <NavLink to="/castells/Vd6f">vano de 6</NavLink>.
+					No gaire més tard, l'hivern del 2014, vam portar a la Diada dels Ganàpies de la UAB el primer <NavLink to="/castells/3d8f/">3 de 8 amb folre</NavLink> del món universitari, que veia com es feia història un altre cop en descarregar aquest castell fins aleshores inèdit. Aquell mateix desembre, pel nostre 19è Aniversari, sorpreníem el món sencer obrint plaça amb el <NavLink to="/castells/Vd6f/">vano de 6</NavLink>.
 				</p>
 			</section>
 			{
@@ -73,13 +73,13 @@ class HistoriaDeLaColla extends Component {
 			<section className="historia">
 				<h5>L'època d'or</h5>
 				<p>
-					La següent temporada els Arreplegats vam seguir escrivint la història dels castells. El maig de 2015, en la nostra 20a Diada, vam descarregar el primer <NavLink to="/castells/9d7">9 de 7</NavLink> universitari que mai ningú ha tornat a intentar.
+					La següent temporada els Arreplegats vam seguir escrivint la història dels castells. El maig de 2015, en la nostra 20a Diada, vam descarregar el primer <NavLink to="/castells/9d7/">9 de 7</NavLink> universitari que mai ningú ha tornat a intentar.
 				</p>
 				<p>
-					Aquests anys vam dominar tots els grans castells. Podíem fer, amb relativa facilitat, els castells més complicats del món casteller universitari, castells que ningú ha pogut igualar encara. Vam passejar per tot arreu els ja esmentats <NavLink to="/castells/3d8f">3 de 8 amb folre</NavLink>, <NavLink to="/castells/3d7s">3 de 7 per sota</NavLink>, <NavLink to="/castells/5d7">5 de 7</NavLink>, i <NavLink to="/castells/4d8">4 de 8</NavLink> demostrant el nostre domini per totes les places on passàvem.
+					Aquests anys vam dominar tots els grans castells. Podíem fer, amb relativa facilitat, els castells més complicats del món casteller universitari, castells que ningú ha pogut igualar encara. Vam passejar per tot arreu els ja esmentats <NavLink to="/castells/3d8f/">3 de 8 amb folre</NavLink>, <NavLink to="/castells/3d7s/">3 de 7 per sota</NavLink>, <NavLink to="/castells/5d7/">5 de 7</NavLink>, i <NavLink to="/castells/4d8/">4 de 8</NavLink> demostrant el nostre domini per totes les places on passàvem.
 				</p>
 				<p>
-					Aquesta època gloriosa va assolir el seu punt més àlgid el 5 de maig del 2016, on vam ajuntar el <NavLink to="/castells/3d8f">3 de 8 amb folre</NavLink>, el <NavLink to="/castells/4d8">4 de 8</NavLink>, i vam carregar la inèdita <NavLink to="/castells/Td8fm">torre de 8 amb folre i manilles</NavLink> en una diada històrica.
+					Aquesta època gloriosa va assolir el seu punt més àlgid el 5 de maig del 2016, on vam ajuntar el <NavLink to="/castells/3d8f/">3 de 8 amb folre</NavLink>, el <NavLink to="/castells/4d8/">4 de 8</NavLink>, i vam carregar la inèdita <NavLink to="/castells/Td8fm/">torre de 8 amb folre i manilles</NavLink> en una diada històrica.
 				</p>
 			</section>
 			{
@@ -93,7 +93,7 @@ class HistoriaDeLaColla extends Component {
 					En reprendre l'activitat castellera després del confinament, hi havia molta feina a fer. Renovació, formació, recaptació de nous castellers, etc. Va ser un procés llarg, però no per això el vam encarar amb menys il·lusió.
 				</p>
 				<p>
-					La diada més important des d'aleshores ha estat el nostre 27è Aniversari, el 22 de desembre de 2022. Després d'una gran temporada amb molta formació, vam poder conrear els fruits de tota la feina feta, i vam fer-hi el primer <NavLink to="/castells/5d7">5 de 7</NavLink> universitari post-COVID, el primer <NavLink to="/castells/3d8f">3 de 8 amb folre</NavLink> universitari post-COVID, la nostra quarta torre de 7 amb folre de la temporada, i hi vam carregar el <NavLink to="/castells/Pd7fm">pilar de 7 amb folre i manilles</NavLink>. Aquest pilar no només representava les primeres manilles universitàries post-COVID, sinó que també ens va convertir en la sisena colla global en fer unes manilles després de la pandèmia.
+					La diada més important des d'aleshores ha estat el nostre 27è Aniversari, el 22 de desembre de 2022. Després d'una gran temporada amb molta formació, vam poder conrear els fruits de tota la feina feta, i vam fer-hi el primer <NavLink to="/castells/5d7/">5 de 7</NavLink> universitari post-COVID, el primer <NavLink to="/castells/3d8f/">3 de 8 amb folre</NavLink> universitari post-COVID, la nostra quarta torre de 7 amb folre de la temporada, i hi vam carregar el <NavLink to="/castells/Pd7fm/">pilar de 7 amb folre i manilles</NavLink>. Aquest pilar no només representava les primeres manilles universitàries post-COVID, sinó que també ens va convertir en la sisena colla global en fer unes manilles després de la pandèmia.
 				</p>
 			</section>
 		</>);

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -15,7 +15,7 @@ class Home extends Component {
 			<section style={{paddingTop: `2rem`}}>
 				<div className="floating-titles">
 					<h4>Els millors castells</h4>
-					<NavLink to="/millors-castells">Descobreix-los tots!</NavLink>
+					<NavLink to="/millors-castells/">Descobreix-los tots!</NavLink>
 				</div>
 				<div className="top-gallery">
 					{

--- a/src/pages/Jocs.js
+++ b/src/pages/Jocs.js
@@ -18,7 +18,7 @@ class Jocs extends Component {
 				<div className="games">
 					{
 						Object.entries(jocs_list).map(([k, v], i) => {
-							return <NavLink key={i} className="game btn" to={`/${v}`}>
+							return <NavLink key={i} className="game btn" to={`/${v}/`}>
 								<span>{k}</span>
 							</NavLink>;
 						})

--- a/src/pages/JuntaDirectiva.js
+++ b/src/pages/JuntaDirectiva.js
@@ -22,7 +22,7 @@ class JuntaDirectiva extends Component {
 		return (<>
 			<section>
 				<h2>Junta directiva</h2>
-				{ any && <p className="junta-message"><span>Atenció!</span> Estàs consultant la junta d'una temporada anterior. Per veure'n l'actual fes click <NavLink to="/junta-directiva">aquí</NavLink>.</p> }
+				{ any && <p className="junta-message"><span>Atenció!</span> Estàs consultant la junta d'una temporada anterior. Per veure'n l'actual fes click <NavLink to="/junta-directiva/">aquí</NavLink>.</p> }
 
 				<p>
 					La Junta Directiva és dirigida per l'equip de presidència. Ha de constar també de secretaria, tresoreria, comissió tècnica i comissió feminista. Actualment, també existeixen les comissions: material, acolliment social, músics, logística i contractació, promoció i difusió, equip sanitari i activitats.
@@ -36,10 +36,10 @@ class JuntaDirectiva extends Component {
 				<div className="junta-year-wrap">
 					{
 						Object.keys(junta.anteriors).sort().map((y, i) => {
-							return <NavLink className={`junta-year ${junta_temporada === junta.anteriors[y]}`} to={`/junta-directiva/${y}`} key={`year-${i}`}>{y}</NavLink>;
+							return <NavLink className={`junta-year ${junta_temporada === junta.anteriors[y]}`} to={`/junta-directiva/${y}/`} key={`year-${i}`}>{y}</NavLink>;
 						})
 					}
-					<NavLink className={`junta-year ${junta_temporada === junta.actual}`} to="/junta-directiva">ACTUAL</NavLink>
+					<NavLink className={`junta-year ${junta_temporada === junta.actual}`} to="/junta-directiva/">ACTUAL</NavLink>
 				</div>
 
 				<JuntaTeams

--- a/src/pages/JuntaTecnica.js
+++ b/src/pages/JuntaTecnica.js
@@ -22,7 +22,7 @@ class JuntaTecnica extends Component {
 		return (<>
 			<section>
 				<h2>Junta tècnica{any && ` (${any})`}</h2>
-				{ any && <p className="junta-message"><span>Atenció!</span> Estàs consultant la junta d'una temporada anterior. Per veure'n l'actual fes click <NavLink to="/junta-tecnica">aquí</NavLink>.</p> }
+				{ any && <p className="junta-message"><span>Atenció!</span> Estàs consultant la junta d'una temporada anterior. Per veure'n l'actual fes click <NavLink to="/junta-tecnica/">aquí</NavLink>.</p> }
 
 				<p>
 					La Junta Tècnica està formada per cap de colla i sots-cap de colla al capdavant. Els equips de la Junta Tècnica els decideixen cap i sots-cap de colla. Generalment consta de d'un equip de troncs; un equip de pinyes, folres, i manilles; i un de poms.
@@ -36,10 +36,10 @@ class JuntaTecnica extends Component {
 				<div className="junta-year-wrap">
 					{
 						Object.keys(junta.anteriors).sort().map((y, i) => {
-							return <NavLink className={`junta-year ${junta_temporada === junta.anteriors[y]}`} to={`/junta-tecnica/${y}`} key={`year-${i}`}>{y}</NavLink>;
+							return <NavLink className={`junta-year ${junta_temporada === junta.anteriors[y]}`} to={`/junta-tecnica/${y}/`} key={`year-${i}`}>{y}</NavLink>;
 						})
 					}
-					<NavLink className={`junta-year ${junta_temporada === junta.actual}`} to="/junta-tecnica">ACTUAL</NavLink>
+					<NavLink className={`junta-year ${junta_temporada === junta.actual}`} to="/junta-tecnica/">ACTUAL</NavLink>
 				</div>
 
 				<JuntaTeams

--- a/src/pages/NivellsMotsEncreuats.js
+++ b/src/pages/NivellsMotsEncreuats.js
@@ -20,7 +20,7 @@ class NivellsMotsEncreuats extends Component {
 				<div className="game-levels">
 					{
 						maps.map((_, i) => {
-							return <NavLink key={i} className={`btn ${this.getCookie(`mots-${i}`) === 'true' ? '' : 'incomplete'}`} to={`/mots-encreuats/${i}`}>Nivell {i+1}</NavLink>;
+							return <NavLink key={i} className={`btn ${this.getCookie(`mots-${i}`) === 'true' ? '' : 'incomplete'}`} to={`/mots-encreuats/${i}/`}>Nivell {i+1}</NavLink>;
 						})
 					}
 				</div>

--- a/src/pages/NivellsPenjat.js
+++ b/src/pages/NivellsPenjat.js
@@ -20,7 +20,7 @@ class NivellsPenjat extends Component {
 				<div className="game-levels">
 					{
 						maps.map((_, i) => {
-							return <NavLink key={i} className={`btn ${this.getCookie(`penjat-${i}`) === 'true' ? '' : 'incomplete'}`} to={`/penjat/${i}`}>Nivell {i+1}</NavLink>;
+							return <NavLink key={i} className={`btn ${this.getCookie(`penjat-${i}`) === 'true' ? '' : 'incomplete'}`} to={`/penjat/${i}/`}>Nivell {i+1}</NavLink>;
 						})
 					}
 				</div>

--- a/src/pages/NivellsSopaDeLletres.js
+++ b/src/pages/NivellsSopaDeLletres.js
@@ -20,7 +20,7 @@ class NivellsSopaDeLletres extends Component {
 				<div className="game-levels">
 					{
 						maps.map((_, i) => {
-							return <NavLink key={i} className={`btn ${this.getCookie(`sopa-${i}`) === 'true' ? '' : 'incomplete'}`} to={`/sopa-de-lletres/${i}`}>Nivell {i+1}</NavLink>;
+							return <NavLink key={i} className={`btn ${this.getCookie(`sopa-${i}`) === 'true' ? '' : 'incomplete'}`} to={`/sopa-de-lletres/${i}/`}>Nivell {i+1}</NavLink>;
 						})
 					}
 				</div>

--- a/src/pages/QuiSom.js
+++ b/src/pages/QuiSom.js
@@ -33,10 +33,10 @@ class QuiSom extends Component {
 					Els Arreplegats som una colla castellera amb més de 25 anys d'història que només fem castells amb persones matriculades a la universitat. Fins i tot les enxanetes són adultes!
 				</p>
 				<p>
-					Tot i aquesta restricció única, hem aconseguit arribar a nivells molt alts en les nostres actuacions. Alcem castells, torres i pilars de fins a 8 pisos com el <NavLink to="/castells/4d8">4 de 8</NavLink>, la <NavLink to="/castells/Td8fm">torre de 8 amb folre i manilles</NavLink>, o el <NavLink to="/castells/3d8f">tres de 8 amb folre</NavLink>, capaços de satisfer el públic més exigent.
+					Tot i aquesta restricció única, hem aconseguit arribar a nivells molt alts en les nostres actuacions. Alcem castells, torres i pilars de fins a 8 pisos com el <NavLink to="/castells/4d8/">4 de 8</NavLink>, la <NavLink to="/castells/Td8fm/">torre de 8 amb folre i manilles</NavLink>, o el <NavLink to="/castells/3d8f/">tres de 8 amb folre</NavLink>, capaços de satisfer el públic més exigent.
 				</p>
 				<div className="read-more">
-					<NavLink to="/historia-de-la-colla">DESCOBREIX LA NOSTRA HISTÒRIA!</NavLink>
+					<NavLink to="/historia-de-la-colla/">DESCOBREIX LA NOSTRA HISTÒRIA!</NavLink>
 				</div>
 			</section>
 		</>);


### PR DESCRIPTION
## What changed

- Updated React Router internal links to use canonical trailing-slash URLs.
- Updated `public/index.html` noscript links to point directly at trailing-slash routes.
- Added tests for navbar, hero, castell cards, and fallback links so canonical internal URLs stay enforced.

## Why

The site serves generated route entrypoints with trailing-slash canonical URLs. Internal links without the slash can incur a 301 before reaching the canonical route, especially for crawlers and users opening links directly.

## Validation

- `npm test -- --watchAll=false`
- `npm run build`
- `git diff --check`
- Local Chrome headless check against the built home page found no internal page anchor without a trailing slash.