### PR TITLE
[codex] Align sitemap with public routes

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -109,6 +109,24 @@
     <loc>https://arreplegats.cat/jocs/</loc>
   </url>
   <url>
+    <loc>https://arreplegats.cat/joc-castells/</loc>
+  </url>
+  <url>
+    <loc>https://arreplegats.cat/sopa-de-lletres/</loc>
+  </url>
+  <url>
+    <loc>https://arreplegats.cat/mots-encreuats/</loc>
+  </url>
+  <url>
+    <loc>https://arreplegats.cat/memory/</loc>
+  </url>
+  <url>
+    <loc>https://arreplegats.cat/penjat/</loc>
+  </url>
+  <url>
     <loc>https://arreplegats.cat/contactar/</loc>
+  </url>
+  <url>
+    <loc>https://arreplegats.cat/parts-castell/</loc>
   </url>
 </urlset>

--- a/scripts/generate-route-entrypoints.js
+++ b/scripts/generate-route-entrypoints.js
@@ -10,6 +10,7 @@ const castellsTopPath = path.join(rootDir, "src", "data", "castells-top.json");
 const routeMetaPath = path.join(rootDir, "src", "data", "routeMeta.json");
 const siteUrl = "https://arreplegats.cat";
 const routeMeta = JSON.parse(fs.readFileSync(routeMetaPath, "utf8"));
+const dynamicRouteSegments = ["castells"];
 
 // Keep this list to public, stable routes that should deep-link on static hosts.
 // Utility, private, event-specific, and generated game-level routes stay on the
@@ -52,6 +53,15 @@ function getCastellRoutes() {
   const castellsTop = JSON.parse(fs.readFileSync(castellsTopPath, "utf8"));
 
   return Object.keys(castellsTop).map((slug) => `/castells/${slug}`);
+}
+
+function getStaticRoutes() {
+  const routes = [...publicRoutes];
+  const castellsIndex = routes.indexOf("/millors-castells") + 1;
+
+  routes.splice(castellsIndex, 0, ...getCastellRoutes());
+
+  return [...new Set(routes)];
 }
 
 function assertSafeRoute(route) {
@@ -126,7 +136,7 @@ function main() {
   }
 
   const indexHtml = fs.readFileSync(indexHtmlPath, "utf8");
-  const routes = [...new Set([...publicRoutes, ...getCastellRoutes()])];
+  const routes = getStaticRoutes();
 
   for (const route of routes) {
     const outputPath = getOutputPath(route);
@@ -142,7 +152,10 @@ if (require.main === module) {
 }
 
 module.exports = {
+  dynamicRouteSegments,
   getCanonicalUrl,
   getRouteMeta,
+  getStaticRoutes,
+  publicRoutes,
   setRouteUrlMeta,
 };

--- a/src/data/routeMeta.json
+++ b/src/data/routeMeta.json
@@ -128,21 +128,9 @@
 			"title": "Contactar - Arreplegats",
 			"description": "Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials."
 		},
-		"barra-lliure": {
-			"title": "Barra Lliure - Arreplegats",
-			"description": "Pàgina de barra lliure dels Arreplegats de la Zona Universitària."
-		},
 		"parts-castell": {
 			"title": "Parts Castell - Arreplegats",
 			"description": "Aprèn les parts principals d'un castell amb els Arreplegats de la Zona Universitària."
-		},
-		"nit-fresca-per-ser-maig": {
-			"title": "Una Nit de Maig - Arreplegats",
-			"description": "Informació de l'esdeveniment Una Nit de Maig dels Arreplegats de la Zona Universitària."
-		},
-		"palette": {
-			"title": "Palette - Arreplegats",
-			"description": "Paleta de colors dels Arreplegats de la Zona Universitària."
 		},
 		"joc-castells": {
 			"title": "Joc Castells - Arreplegats",

--- a/src/generateRouteEntrypoints.test.js
+++ b/src/generateRouteEntrypoints.test.js
@@ -1,8 +1,12 @@
 const {
+  dynamicRouteSegments,
   getCanonicalUrl,
   getRouteMeta,
+  getStaticRoutes,
+  publicRoutes,
   setRouteUrlMeta,
 } = require("../scripts/generate-route-entrypoints");
+const routeMeta = require("./data/routeMeta.json");
 
 const baseHtml = `
   <title>Arreplegats de la Zona Universitària | Colla Castellera</title>
@@ -30,6 +34,33 @@ describe("route entrypoint metadata", () => {
       title: "Assajos - Arreplegats",
       description: "Vine als assajos dels Arreplegats: dimarts i dijous al migdia a l'ETSEIB i dijous al vespre amb Castellers de Sants.",
     });
+  });
+
+  test("keeps route metadata scoped to static entrypoints and dynamic namespaces", () => {
+    const staticRouteSegments = publicRoutes.map((route) => route.split("/")[1]);
+    const allowedRouteMetaSegments = new Set([
+      "",
+      ...staticRouteSegments,
+      ...dynamicRouteSegments,
+    ]);
+
+    const staleRouteMeta = Object.keys(routeMeta.routes).filter(
+      (routeSegment) => !allowedRouteMetaSegments.has(routeSegment)
+    );
+
+    expect(staleRouteMeta).toEqual([]);
+  });
+
+  test("generates static routes for every public route and top castell page", () => {
+    const staticRoutes = getStaticRoutes();
+
+    for (const route of publicRoutes) {
+      expect(staticRoutes).toContain(route);
+    }
+
+    expect(new Set(staticRoutes).size).toBe(staticRoutes.length);
+    expect(staticRoutes).toContain("/castells/Td8fm");
+    expect(staticRoutes.filter((route) => route.startsWith("/castells/")).length).toBeGreaterThan(0);
   });
 
   test("replaces home URL metadata on generated route entrypoints", () => {

--- a/src/sitemap.test.js
+++ b/src/sitemap.test.js
@@ -1,5 +1,9 @@
 const fs = require("fs");
 const path = require("path");
+const {
+	getCanonicalUrl,
+	getStaticRoutes,
+} = require("../scripts/generate-route-entrypoints");
 
 const sitemapPath = path.join(__dirname, "..", "public", "sitemap.xml");
 
@@ -22,5 +26,15 @@ describe("sitemap URLs", () => {
 
 			expect(pathname.endsWith("/")).toBe(true);
 		}
+	});
+
+	test("stays aligned with static public route entrypoints", () => {
+		const urls = getSitemapUrls();
+		const expectedUrls = [
+			"https://arreplegats.cat/",
+			...getStaticRoutes().map(getCanonicalUrl),
+		];
+
+		expect(urls).toEqual(expectedUrls);
 	});
 });


### PR DESCRIPTION
## Summary
- Export the static public route list from the route-entrypoint generator so sitemap tests use the same route source.
- Add missing public static routes to `public/sitemap.xml`, including the game routes and `parts-castell`.
- Remove SEO metadata entries for client-only or temporary routes that are not promoted to static/indexable entrypoints.

## Why
The sitemap and generated static route entrypoints had drifted: several public generated routes were missing from the sitemap, while `routeMeta` still described routes that return 404 when requested directly on GitHub Pages.

## Validation
- `CI=true npm test -- --runTestsByPath src/sitemap.test.js src/generateRouteEntrypoints.test.js --watchAll=false`
- `CI=true npm test -- --watchAll=false`
- `npm run build`
