### PR TITLE
[codex] Improve route SEO metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,14 +7,14 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Pàgina web oficial de la colla de castellers dels Arreplegats de la Zona Universitària. Dades, contractar, i més!"
+      content="Web oficial dels Arreplegats de la Zona Universitària: castells universitaris, assajos, agenda i vida de la colla."
     />
     <meta name="title" content="Arreplegats de la Zona Universitària | Colla Castellera">
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arreplegats.cat/">
     <meta property="og:title" content="Arreplegats de la Zona Universitària | Colla Castellera">
-    <meta property="og:description" content="Pàgina web oficial de la colla de castellers dels Arreplegats de la Zona Universitària. Dades, contractar, i més!">
+    <meta property="og:description" content="Web oficial dels Arreplegats de la Zona Universitària: castells universitaris, assajos, agenda i vida de la colla.">
     <meta property="og:image" content="https://arreplegats.cat/og-image.jpg">
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:width" content="1200">
@@ -24,7 +24,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://arreplegats.cat/">
     <meta property="twitter:title" content="Arreplegats de la Zona Universitària | Colla Castellera">
-    <meta property="twitter:description" content="Pàgina web oficial de la colla de castellers dels Arreplegats de la Zona Universitària. Dades, contractar, i més!">
+    <meta property="twitter:description" content="Web oficial dels Arreplegats de la Zona Universitària: castells universitaris, assajos, agenda i vida de la colla.">
     <meta property="twitter:image" content="https://arreplegats.cat/og-image.jpg">
     <meta property="twitter:image:alt" content="Arreplegats de la Zona Universitària fent un castell">
     <!--

--- a/scripts/generate-route-entrypoints.js
+++ b/scripts/generate-route-entrypoints.js
@@ -7,10 +7,9 @@ const rootDir = path.resolve(__dirname, "..");
 const buildDir = path.join(rootDir, "build");
 const indexHtmlPath = path.join(buildDir, "index.html");
 const castellsTopPath = path.join(rootDir, "src", "data", "castells-top.json");
-const routeMetaPath = path.join(rootDir, "src", "data", "routeMeta.json");
 const siteUrl = "https://arreplegats.cat";
-const routeMeta = JSON.parse(fs.readFileSync(routeMetaPath, "utf8"));
 const dynamicRouteSegments = ["castells"];
+const { getRouteMeta } = require("../src/data/routeMetadata");
 
 // Keep this list to public, stable routes that should deep-link on static hosts.
 // Utility, private, event-specific, and generated game-level routes stay on the
@@ -91,12 +90,6 @@ function getCanonicalUrl(route) {
   assertSafeRoute(route);
 
   return `${siteUrl}${route.replace(/\/?$/, "/")}`;
-}
-
-function getRouteMeta(route) {
-  const firstWord = route.split("/")?.[1] || "";
-
-  return routeMeta.routes[firstWord] || routeMeta.default;
 }
 
 function escapeHtml(value) {

--- a/src/components/TitleUpdater.js
+++ b/src/components/TitleUpdater.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import routeMeta from "../data/routeMeta.json";
+import routeMetadata from "../data/routeMetadata";
 
 function setMetaContent(selector, content) {
 	const element = document.head.querySelector(selector);
@@ -11,9 +11,7 @@ function setMetaContent(selector, content) {
 }
 
 export function getRouteMeta(pathname) {
-	const firstWord = pathname.split("/")?.[1] || "";
-
-	return routeMeta.routes[firstWord] || routeMeta.default;
+	return routeMetadata.getRouteMeta(pathname);
 }
 
 const TitleUpdater = () => {

--- a/src/components/TitleUpdater.test.js
+++ b/src/components/TitleUpdater.test.js
@@ -35,34 +35,48 @@ describe("TitleUpdater", () => {
 
 	test("returns route-specific metadata for important pages", () => {
 		expect(getRouteMeta("/assajos")).toEqual({
-			title: "Assajos - Arreplegats",
-			description: "Vine als assajos dels Arreplegats: dimarts i dijous al migdia a l'ETSEIB i dijous al vespre amb Castellers de Sants.",
+			title: "Assajos castellers universitaris a Barcelona | Arreplegats",
+			description: "Horaris i espais d'assaig dels Arreplegats de la Zona Universitària, amb assajos a l'ETSEIB i sessions conjuntes amb Castellers de Sants.",
 		});
 	});
 
 	test("updates document title and description meta tags for the active route", () => {
 		renderTitleUpdater("/qui-som");
 
-		expect(document.title).toBe("Qui Som - Arreplegats");
-		expect(document.head.querySelector('meta[name="title"]')).toHaveAttribute("content", "Qui Som - Arreplegats");
+		expect(document.title).toBe("Qui són els Arreplegats de la Zona Universitària");
+		expect(document.head.querySelector('meta[name="title"]')).toHaveAttribute("content", "Qui són els Arreplegats de la Zona Universitària");
 		expect(document.head.querySelector('meta[name="description"]')).toHaveAttribute(
 			"content",
-			"Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d'història."
+			"Coneix la colla castellera universitària de Barcelona: qui forma els Arreplegats, què fem i com vivim els castells a la Zona Universitària."
 		);
+	});
+
+	test("keeps the home route from downgrading the static social title", () => {
+		expect(getRouteMeta("/")).toEqual({
+			title: "Arreplegats de la Zona Universitària | Colla Castellera",
+			description: "Web oficial dels Arreplegats de la Zona Universitària: castells universitaris, assajos, agenda i vida de la colla.",
+		});
+	});
+
+	test("returns castell-specific metadata for castell detail pages", () => {
+		expect(getRouteMeta("/castells/Td8fm/")).toEqual({
+			title: "Torre de 8 amb folre i manilles (Td8fm) | Arreplegats",
+			description: "Fitxa de la Torre de 8 amb folre i manilles (Td8fm) dels Arreplegats, amb imatges, història i context dins dels castells universitaris.",
+		});
 	});
 
 	test("keeps Open Graph and Twitter metadata aligned with route metadata", () => {
 		renderTitleUpdater("/contactar");
 
-		expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", "Contactar - Arreplegats");
-		expect(document.head.querySelector('meta[property="twitter:title"]')).toHaveAttribute("content", "Contactar - Arreplegats");
+		expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", "Contacta amb els Arreplegats de la Zona Universitària");
+		expect(document.head.querySelector('meta[property="twitter:title"]')).toHaveAttribute("content", "Contacta amb els Arreplegats de la Zona Universitària");
 		expect(document.head.querySelector('meta[property="og:description"]')).toHaveAttribute(
 			"content",
-			"Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials."
+			"Canals per contactar amb la colla castellera Arreplegats de la Zona Universitària: correu electrònic, xarxes socials i informació de contacte."
 		);
 		expect(document.head.querySelector('meta[property="twitter:description"]')).toHaveAttribute(
 			"content",
-			"Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials."
+			"Canals per contactar amb la colla castellera Arreplegats de la Zona Universitària: correu electrònic, xarxes socials i informació de contacte."
 		);
 	});
 });

--- a/src/data/routeMeta.json
+++ b/src/data/routeMeta.json
@@ -5,136 +5,136 @@
 	},
 	"routes": {
 		"": {
-			"title": "Inici - Arreplegats",
+			"title": "Arreplegats de la Zona Universitària | Colla Castellera",
 			"description": "Web oficial dels Arreplegats de la Zona Universitària: castells universitaris, assajos, agenda i vida de la colla."
 		},
 		"qui-som": {
-			"title": "Qui Som - Arreplegats",
-			"description": "Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d'història."
+			"title": "Qui són els Arreplegats de la Zona Universitària",
+			"description": "Coneix la colla castellera universitària de Barcelona: qui forma els Arreplegats, què fem i com vivim els castells a la Zona Universitària."
 		},
 		"agenda": {
-			"title": "Agenda - Arreplegats",
-			"description": "Consulta l'agenda d'assajos, activitats i actuacions dels Arreplegats de la Zona Universitària."
+			"title": "Agenda d'assajos i actuacions | Arreplegats",
+			"description": "Consulta l'agenda d'assajos, activitats i actuacions dels Arreplegats de la Zona Universitària al calendari casteller universitari."
 		},
 		"assajos": {
-			"title": "Assajos - Arreplegats",
-			"description": "Vine als assajos dels Arreplegats: dimarts i dijous al migdia a l'ETSEIB i dijous al vespre amb Castellers de Sants."
+			"title": "Assajos castellers universitaris a Barcelona | Arreplegats",
+			"description": "Horaris i espais d'assaig dels Arreplegats de la Zona Universitària, amb assajos a l'ETSEIB i sessions conjuntes amb Castellers de Sants."
 		},
 		"gralles-i-tabals": {
-			"title": "Gralles i Tabals - Arreplegats",
-			"description": "Descobreix el grup de gralles i tabals dels Arreplegats i la música que acompanya els castells universitaris."
+			"title": "Gralles i tabals castellers | Arreplegats",
+			"description": "Descobreix el grup de gralles i tabals dels Arreplegats, la música que acompanya els castells universitaris i com participar-hi."
 		},
 		"vida-universitaria": {
-			"title": "Vida Universitària - Arreplegats",
-			"description": "Activitats, convivència i vida universitària al voltant de la colla castellera Arreplegats de la Zona Universitària."
+			"title": "Vida universitària i activitats | Arreplegats",
+			"description": "Activitats, convivència i vida universitària al voltant dels Arreplegats de la Zona Universitària més enllà dels castells."
 		},
 		"historia-de-la-colla": {
-			"title": "Història de la Colla - Arreplegats",
-			"description": "Repàs de la història dels Arreplegats, des de la fundació el 1995 fins als grans castells universitaris."
+			"title": "Història dels Arreplegats de la Zona Universitària",
+			"description": "Repàs de la història dels Arreplegats, des de la fundació el 1995 fins als grans castells que han marcat el món universitari."
 		},
 		"llista-de-caps-de-colla": {
-			"title": "Llista de Caps de Colla - Arreplegats",
-			"description": "Llista històrica de caps de colla dels Arreplegats de la Zona Universitària."
+			"title": "Caps de colla dels Arreplegats | Històric",
+			"description": "Llista històrica dels caps de colla dels Arreplegats de la Zona Universitària i de les temporades que han liderat."
 		},
 		"llista-de-presidents": {
-			"title": "Llista de Presidents - Arreplegats",
-			"description": "Llista històrica de presidents i presidentes dels Arreplegats de la Zona Universitària."
+			"title": "Presidències dels Arreplegats | Històric",
+			"description": "Llista històrica de presidents i presidentes dels Arreplegats de la Zona Universitària al llarg de les temporades de la colla."
 		},
 		"els-castells-universitaris": {
-			"title": "Els Castells Universitaris - Arreplegats",
-			"description": "Història i evolució dels castells universitaris, amb els principals fets i colles del món casteller universitari."
+			"title": "Castells universitaris: història i colles | Arreplegats",
+			"description": "Història i evolució dels castells universitaris, amb els principals fets, colles i fites del món casteller universitari."
 		},
 		"millors-castells": {
-			"title": "Millors Castells - Arreplegats",
-			"description": "Consulta els millors castells descarregats i carregats pels Arreplegats de la Zona Universitària."
+			"title": "Millors castells dels Arreplegats | Rànquing",
+			"description": "Consulta el rànquing dels millors castells descarregats i carregats pels Arreplegats de la Zona Universitària."
 		},
 		"castells": {
-			"title": "Castell - Arreplegats",
-			"description": "Fitxa d'un castell dels Arreplegats amb imatges, informació i context històric de la construcció."
+			"title": "Fitxes de castells universitaris | Arreplegats",
+			"description": "Fitxes dels castells dels Arreplegats de la Zona Universitària amb imatges, informació i context històric de cada construcció."
 		},
 		"millors-diades": {
-			"title": "Millors Diades - Arreplegats",
-			"description": "Rànquing de les millors diades dels Arreplegats segons les puntuacions del Baròmetre Universitari."
+			"title": "Millors diades dels Arreplegats | Rànquing",
+			"description": "Rànquing de les millors diades dels Arreplegats segons les puntuacions del Baròmetre Universitari i els castells assolits."
 		},
 		"resum-historic": {
-			"title": "Resum Històric - Arreplegats",
-			"description": "Resum històric de temporades, castells i actuacions dels Arreplegats de la Zona Universitària."
+			"title": "Resum històric de temporades | Arreplegats",
+			"description": "Resum històric de temporades, castells, actuacions i evolució dels Arreplegats de la Zona Universitària."
 		},
 		"llista-de-diades": {
-			"title": "Llista de Diades - Arreplegats",
-			"description": "Consulta la llista de diades i actuacions dels Arreplegats amb els castells de cada jornada."
+			"title": "Llista de diades i actuacions | Arreplegats",
+			"description": "Consulta la llista de diades i actuacions dels Arreplegats de la Zona Universitària amb els castells de cada jornada."
 		},
 		"junta-directiva": {
-			"title": "Junta Directiva - Arreplegats",
-			"description": "Equip de junta directiva dels Arreplegats de la Zona Universitària."
+			"title": "Junta directiva dels Arreplegats | Equip actual",
+			"description": "Equip de junta directiva dels Arreplegats de la Zona Universitària i responsabilitats organitzatives de la colla."
 		},
 		"junta-tecnica": {
-			"title": "Junta Tècnica - Arreplegats",
-			"description": "Equip de junta tècnica dels Arreplegats de la Zona Universitària."
+			"title": "Junta tècnica dels Arreplegats | Equip actual",
+			"description": "Equip de junta tècnica dels Arreplegats de la Zona Universitària i àrees responsables del treball casteller."
 		},
 		"comissio-genere-grup-treball": {
-			"title": "Comissió de Gènere - Arreplegats",
-			"description": "Comissió de gènere i grup de treball dels Arreplegats de la Zona Universitària."
+			"title": "Comissió de gènere dels Arreplegats",
+			"description": "Comissió de gènere i grup de treball dels Arreplegats de la Zona Universitària per construir una colla més segura i inclusiva."
 		},
 		"patrocinadors": {
-			"title": "Patrocinadors - Arreplegats",
-			"description": "Patrocinadors, col·laboradors i entitats que donen suport als Arreplegats de la Zona Universitària."
+			"title": "Patrocinadors i col·laboradors | Arreplegats",
+			"description": "Patrocinadors, col·laboradors i entitats que donen suport als Arreplegats de la Zona Universitària i al projecte casteller."
 		},
 		"fotografies": {
-			"title": "Fotografies - Arreplegats",
-			"description": "Galeria fotogràfica dels Arreplegats de la Zona Universitària."
+			"title": "Fotografies de castells universitaris | Arreplegats",
+			"description": "Galeria fotogràfica dels Arreplegats de la Zona Universitària amb imatges de castells, diades i vida de la colla."
 		},
 		"videos": {
-			"title": "Vídeos - Arreplegats",
-			"description": "Vídeos de castells, actuacions i continguts dels Arreplegats de la Zona Universitària."
+			"title": "Vídeos de castells dels Arreplegats",
+			"description": "Vídeos de castells, actuacions, assajos i continguts dels Arreplegats de la Zona Universitària."
 		},
 		"musica": {
-			"title": "Música - Arreplegats",
-			"description": "Cançons, partitures i música dels Arreplegats de la Zona Universitària."
+			"title": "Música, gralles i tabals | Arreplegats",
+			"description": "Cançons, partitures i música dels Arreplegats de la Zona Universitària, amb recursos per a gralles i tabals."
 		},
 		"estatuts": {
-			"title": "Estatuts - Arreplegats",
-			"description": "Estatuts vigents i documents històrics dels Arreplegats de la Zona Universitària."
+			"title": "Estatuts dels Arreplegats | Documents oficials",
+			"description": "Estatuts vigents i documents històrics dels Arreplegats de la Zona Universitària per consultar l'organització de la colla."
 		},
 		"reglament-regim-intern": {
-			"title": "Reglament Règim Intern - Arreplegats",
-			"description": "Reglament de règim intern dels Arreplegats de la Zona Universitària."
+			"title": "Reglament de règim intern | Arreplegats",
+			"description": "Reglament de règim intern dels Arreplegats de la Zona Universitària i documents relacionats amb el funcionament de la colla."
 		},
 		"protocol-agressions": {
-			"title": "Protocol Agressions - Arreplegats",
-			"description": "Protocol d'agressions i documents de prevenció dels Arreplegats de la Zona Universitària."
+			"title": "Protocol d'agressions | Arreplegats",
+			"description": "Protocol d'agressions i documents de prevenció dels Arreplegats de la Zona Universitària per a espais segurs dins la colla."
 		},
 		"jocs": {
-			"title": "Jocs - Arreplegats",
-			"description": "Jocs i activitats interactives dels Arreplegats sobre castells i cultura de la colla."
+			"title": "Jocs de castells dels Arreplegats",
+			"description": "Jocs i activitats interactives dels Arreplegats sobre castells, vocabulari casteller i cultura de la colla."
 		},
 		"sopa-de-lletres": {
-			"title": "Sopa de Lletres - Arreplegats",
-			"description": "Sopa de lletres dels Arreplegats amb vocabulari de castells i de la colla."
+			"title": "Sopa de lletres de castells | Arreplegats",
+			"description": "Sopa de lletres dels Arreplegats amb vocabulari de castells, música i vida universitària de la colla."
 		},
 		"mots-encreuats": {
-			"title": "Mots Encreuats - Arreplegats",
-			"description": "Mots encreuats dels Arreplegats amb pistes sobre castells, música i vida universitària."
+			"title": "Mots encreuats de castells | Arreplegats",
+			"description": "Mots encreuats dels Arreplegats amb pistes sobre castells, música, cultura castellera i vida universitària."
 		},
 		"memory": {
-			"title": "Memory - Arreplegats",
-			"description": "Joc de memory dels Arreplegats amb elements del món casteller universitari."
+			"title": "Memory de cultura castellera | Arreplegats",
+			"description": "Joc de memory dels Arreplegats amb elements del món casteller universitari i objectes de la cultura castellera."
 		},
 		"penjat": {
-			"title": "Penjat - Arreplegats",
-			"description": "Joc del penjat dels Arreplegats amb paraules relacionades amb castells i la colla."
+			"title": "Penjat de vocabulari casteller | Arreplegats",
+			"description": "Joc del penjat dels Arreplegats amb paraules relacionades amb castells, música, assajos i vida de la colla."
 		},
 		"contactar": {
-			"title": "Contactar - Arreplegats",
-			"description": "Contacta amb els Arreplegats de la Zona Universitària per correu electrònic o xarxes socials."
+			"title": "Contacta amb els Arreplegats de la Zona Universitària",
+			"description": "Canals per contactar amb la colla castellera Arreplegats de la Zona Universitària: correu electrònic, xarxes socials i informació de contacte."
 		},
 		"parts-castell": {
-			"title": "Parts Castell - Arreplegats",
-			"description": "Aprèn les parts principals d'un castell amb els Arreplegats de la Zona Universitària."
+			"title": "Parts d'un castell explicades | Arreplegats",
+			"description": "Aprèn les parts principals d'un castell amb els Arreplegats de la Zona Universitària i vocabulari bàsic del món casteller."
 		},
 		"joc-castells": {
-			"title": "Joc Castells - Arreplegats",
-			"description": "Joc de gestió castellera dels Arreplegats de la Zona Universitària."
+			"title": "Joc de gestió castellera | Arreplegats",
+			"description": "Joc de gestió castellera dels Arreplegats de la Zona Universitària per crear una colla i fer créixer els seus castells."
 		}
 	}
 }

--- a/src/data/routeMetadata.js
+++ b/src/data/routeMetadata.js
@@ -1,0 +1,52 @@
+const routeMeta = require("./routeMeta.json");
+const castellsTop = require("./castells-top.json");
+
+function getCastellArticle(name) {
+	if (name.startsWith("Torre")) {
+		return "de la";
+	}
+
+	if (name.startsWith("Pilar")) {
+		return "del";
+	}
+
+	if (/^[AEIOUÀÈÉÍÒÓÚ]/i.test(name)) {
+		return "de l'";
+	}
+
+	return "del";
+}
+
+function getCastellMeta(slug) {
+	const castell = castellsTop[slug];
+
+	if (!castell) {
+		return routeMeta.routes.castells || routeMeta.default;
+	}
+
+	const notation = castell.notation || slug;
+	const article = getCastellArticle(castell.name);
+	const separator = article.endsWith("'") ? "" : " ";
+	const title = `${castell.name} (${notation}) | Arreplegats`;
+
+	return {
+		title: title.length >= 30 ? title : `${castell.name} (${notation}) dels Arreplegats | Fitxa`,
+		description: `Fitxa ${article}${separator}${castell.name} (${notation}) dels Arreplegats, amb imatges, història i context dins dels castells universitaris.`,
+	};
+}
+
+function getRouteMeta(pathname) {
+	const [, firstWord = "", secondWord = ""] = pathname.split("/");
+
+	if (firstWord === "castells" && secondWord) {
+		return getCastellMeta(decodeURIComponent(secondWord));
+	}
+
+	return routeMeta.routes[firstWord] || routeMeta.default;
+}
+
+module.exports = {
+	getCastellMeta,
+	getRouteMeta,
+	routeMeta,
+};

--- a/src/generateRouteEntrypoints.test.js
+++ b/src/generateRouteEntrypoints.test.js
@@ -6,6 +6,7 @@ const {
   publicRoutes,
   setRouteUrlMeta,
 } = require("../scripts/generate-route-entrypoints");
+const castellsTop = require("./data/castells-top.json");
 const routeMeta = require("./data/routeMeta.json");
 
 const baseHtml = `
@@ -31,8 +32,8 @@ describe("route entrypoint metadata", () => {
 
   test("shares route metadata with the client title updater", () => {
     expect(getRouteMeta("/assajos")).toEqual({
-      title: "Assajos - Arreplegats",
-      description: "Vine als assajos dels Arreplegats: dimarts i dijous al migdia a l'ETSEIB i dijous al vespre amb Castellers de Sants.",
+      title: "Assajos castellers universitaris a Barcelona | Arreplegats",
+      description: "Horaris i espais d'assaig dels Arreplegats de la Zona Universitària, amb assajos a l'ETSEIB i sessions conjuntes amb Castellers de Sants.",
     });
   });
 
@@ -63,6 +64,38 @@ describe("route entrypoint metadata", () => {
     expect(staticRoutes.filter((route) => route.startsWith("/castells/")).length).toBeGreaterThan(0);
   });
 
+  test("generates unique metadata for castell detail entrypoints", () => {
+    expect(getRouteMeta("/castells/Td8fm")).toEqual({
+      title: "Torre de 8 amb folre i manilles (Td8fm) | Arreplegats",
+      description: "Fitxa de la Torre de 8 amb folre i manilles (Td8fm) dels Arreplegats, amb imatges, història i context dins dels castells universitaris.",
+    });
+
+    expect(getRouteMeta("/castells/Pd7fm").title).toBe(
+      "Pilar de 7 amb folre i manilles (Pd7fm) | Arreplegats"
+    );
+  });
+
+  test("keeps public route titles descriptive without becoming too long", () => {
+    for (const meta of Object.values(routeMeta.routes)) {
+      expect(meta.title.length).toBeGreaterThanOrEqual(30);
+      expect(meta.title.length).toBeLessThanOrEqual(60);
+      expect(meta.description.length).toBeGreaterThanOrEqual(80);
+      expect(meta.description.length).toBeLessThanOrEqual(165);
+    }
+  });
+
+  test("keeps every castell route title unique and descriptive", () => {
+    const castellTitles = Object.keys(castellsTop).map((slug) => getRouteMeta(`/castells/${slug}`).title);
+
+    expect(new Set(castellTitles).size).toBe(castellTitles.length);
+    expect(castellTitles).not.toContain("Castell - Arreplegats");
+
+    for (const title of castellTitles) {
+      expect(title.length).toBeGreaterThanOrEqual(30);
+      expect(title.length).toBeLessThanOrEqual(60);
+    }
+  });
+
   test("replaces home URL metadata on generated route entrypoints", () => {
     const routeHtml = setRouteUrlMeta(baseHtml, "/assajos");
 
@@ -74,18 +107,18 @@ describe("route entrypoint metadata", () => {
   test("replaces static title and description metadata on generated route entrypoints", () => {
     const routeHtml = setRouteUrlMeta(baseHtml, "/qui-som");
 
-    expect(routeHtml).toContain("<title>Qui Som - Arreplegats</title>");
-    expect(routeHtml).toContain('<meta name="title" content="Qui Som - Arreplegats">');
+    expect(routeHtml).toContain("<title>Qui són els Arreplegats de la Zona Universitària</title>");
+    expect(routeHtml).toContain('<meta name="title" content="Qui són els Arreplegats de la Zona Universitària">');
     expect(routeHtml).toContain(
-      '<meta name="description" content="Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d\'història." />'
+      '<meta name="description" content="Coneix la colla castellera universitària de Barcelona: qui forma els Arreplegats, què fem i com vivim els castells a la Zona Universitària." />'
     );
-    expect(routeHtml).toContain('<meta property="og:title" content="Qui Som - Arreplegats">');
+    expect(routeHtml).toContain('<meta property="og:title" content="Qui són els Arreplegats de la Zona Universitària">');
     expect(routeHtml).toContain(
-      '<meta property="og:description" content="Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d\'història.">'
+      '<meta property="og:description" content="Coneix la colla castellera universitària de Barcelona: qui forma els Arreplegats, què fem i com vivim els castells a la Zona Universitària.">'
     );
-    expect(routeHtml).toContain('<meta property="twitter:title" content="Qui Som - Arreplegats">');
+    expect(routeHtml).toContain('<meta property="twitter:title" content="Qui són els Arreplegats de la Zona Universitària">');
     expect(routeHtml).toContain(
-      '<meta property="twitter:description" content="Coneix els Arreplegats de la Zona Universitària, una colla castellera universitària de Barcelona amb més de 25 anys d\'història.">'
+      '<meta property="twitter:description" content="Coneix la colla castellera universitària de Barcelona: qui forma els Arreplegats, què fem i com vivim els castells a la Zona Universitària.">'
     );
   });
 
@@ -93,7 +126,16 @@ describe("route entrypoint metadata", () => {
     const routeHtml = setRouteUrlMeta(minifiedHtml, "/contactar");
 
     expect(routeHtml).toContain('<link rel="canonical" href="https://arreplegats.cat/contactar/" />');
-    expect(routeHtml).toContain("<title>Contactar - Arreplegats</title>");
-    expect(routeHtml).toContain('<meta property="og:title" content="Contactar - Arreplegats">');
+    expect(routeHtml).toContain("<title>Contacta amb els Arreplegats de la Zona Universitària</title>");
+    expect(routeHtml).toContain('<meta property="og:title" content="Contacta amb els Arreplegats de la Zona Universitària">');
+  });
+
+  test("replaces metadata on castell route entrypoints", () => {
+    const routeHtml = setRouteUrlMeta(baseHtml, "/castells/Td8fm");
+
+    expect(routeHtml).toContain("<title>Torre de 8 amb folre i manilles (Td8fm) | Arreplegats</title>");
+    expect(routeHtml).toContain(
+      '<meta name="description" content="Fitxa de la Torre de 8 amb folre i manilles (Td8fm) dels Arreplegats, amb imatges, història i context dins dels castells universitaris." />'
+    );
   });
 });

--- a/src/ogImage.test.js
+++ b/src/ogImage.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const projectRoot = path.join(__dirname, "..");
 const whatsappRecommendedImageSize = 600 * 1024;
+const routeMeta = require("./data/routeMeta.json");
 
 const getIndexHtml = () => {
   return fs.readFileSync(
@@ -102,6 +103,14 @@ describe("OG image metadata", () => {
     expect(getDocumentTitle()).toBe(title);
     expect(title.length).toBeGreaterThanOrEqual(50);
     expect(title.length).toBeLessThanOrEqual(60);
+  });
+
+  test("uses the homepage SEO description for static social previews", () => {
+    const description = routeMeta.routes[""].description;
+
+    expect(getMetaContent("name", "description")).toBe(description);
+    expect(getMetaContent("property", "og:description")).toBe(description);
+    expect(getMetaContent("property", "twitter:description")).toBe(description);
   });
 
   test("uses the shared social image for Open Graph and Twitter", () => {


### PR DESCRIPTION
## Summary
- Add a shared route metadata resolver used by both React and the static route-entrypoint generator.
- Generate castell-specific titles and descriptions from `castells-top.json` so detail pages no longer share `Castell - Arreplegats`.
- Refresh route titles/descriptions across the site and align the static homepage description with route metadata.
- Add regression tests for homepage metadata, castell metadata uniqueness, title/description length bounds, and static social descriptions.

## Why
The site had generic or short SEO metadata: castell detail URLs shared the same static title, many route titles were only 18-29 characters, and the React title updater changed the homepage title to a weaker value after hydration.

## Validation
- `CI=true npm test -- --runTestsByPath src/components/TitleUpdater.test.js src/generateRouteEntrypoints.test.js --watchAll=false`
- `CI=true npm test -- --watchAll=false`
- `npm run build`
