### PR TITLE
Add Microsoft Clarity tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -118,6 +118,15 @@
 
       gtag('config', 'G-ZM0H0ZH6B6');
     </script>
+
+    <!-- Microsoft Clarity -->
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "y5d8sk4470");
+    </script>
   </head>
   <body>
     <noscript>

--- a/src/clarityTracking.test.js
+++ b/src/clarityTracking.test.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+const indexHtmlPath = path.join(__dirname, "..", "public", "index.html");
+
+function getIndexHtml() {
+	return fs.readFileSync(indexHtmlPath, "utf8");
+}
+
+describe("Microsoft Clarity tracking", () => {
+	test("loads the configured project asynchronously on every page", () => {
+		const indexHtml = getIndexHtml();
+
+		expect(indexHtml).toContain(
+			'(window, document, "clarity", "script", "y5d8sk4470")'
+		);
+		expect(indexHtml).toContain(
+			't.src="https://www.clarity.ms/tag/"+i'
+		);
+		expect(indexHtml).toContain("t.async=1");
+		expect(indexHtml.match(/y5d8sk4470/g)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Resum
- afegeix l’script global de Microsoft Clarity amb el projecte `y5d8sk4470`
- manté la càrrega asíncrona per no bloquejar la pàgina
- afegeix una prova de regressió per validar la configuració

## Validació
- `CI=true npm test -- --runInBand`
- `npm run build`